### PR TITLE
Add Status and JobType enums for application fields

### DIFF
--- a/backend/src/main/java/com/nadavramon/job_tracker/dto/ApplicationRequest.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/dto/ApplicationRequest.java
@@ -1,5 +1,7 @@
 package com.nadavramon.job_tracker.dto;
 
+import com.nadavramon.job_tracker.enums.JobType;
+import com.nadavramon.job_tracker.enums.Status;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.NotBlank;
 
@@ -16,11 +18,11 @@ public class ApplicationRequest {
     @NotBlank
     private String location;
 
-    @NotBlank
-    private String status;
+    @NotNull
+    private Status status;
 
-    @NotBlank
-    private String jobType;
+    @NotNull
+    private JobType jobType;
 
     @NotNull
     private LocalDate appliedDate;
@@ -55,19 +57,19 @@ public class ApplicationRequest {
         this.location = location;
     }
 
-    public String getStatus() {
+    public Status getStatus() {
         return status;
     }
 
-    public void setStatus(String status) {
+    public void setStatus(Status status) {
         this.status = status;
     }
 
-    public String getJobType() {
+    public JobType getJobType() {
         return jobType;
     }
 
-    public void setJobType(String jobType) {
+    public void setJobType(JobType jobType) {
         this.jobType = jobType;
     }
 

--- a/backend/src/main/java/com/nadavramon/job_tracker/entity/Application.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/entity/Application.java
@@ -1,5 +1,7 @@
 package com.nadavramon.job_tracker.entity;
 
+import com.nadavramon.job_tracker.enums.JobType;
+import com.nadavramon.job_tracker.enums.Status;
 import jakarta.persistence.*;
 
 import java.util.UUID;
@@ -18,11 +20,18 @@ public class Application {
     private User user;
 
     private String companyName;
-    private String jobType;
+
+
+    @Enumerated(EnumType.STRING)
+    private JobType jobType;
+
     private String location;
     private String jobRole;
     private LocalDate appliedDate;
-    private String status;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
     private LocalDate statusChangedDate;
     private String websiteLink;
     private String username;
@@ -52,11 +61,11 @@ public class Application {
         this.companyName = companyName;
     }
 
-    public String getJobType() {
+    public JobType getJobType() {
         return jobType;
     }
 
-    public void setJobType(String jobType) {
+    public void setJobType(JobType jobType) {
         this.jobType = jobType;
     }
 
@@ -76,11 +85,11 @@ public class Application {
         this.jobRole = jobRole;
     }
 
-    public String getStatus() {
+    public Status getStatus() {
         return status;
     }
 
-    public void setStatus(String status) {
+    public void setStatus(Status status) {
         this.status = status;
     }
 

--- a/backend/src/main/java/com/nadavramon/job_tracker/enums/JobType.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/enums/JobType.java
@@ -1,0 +1,8 @@
+package com.nadavramon.job_tracker.enums;
+
+public enum JobType {
+    FULL_TIME,
+    PART_TIME,
+    CONTRACT,
+    INTERNSHIP
+}

--- a/backend/src/main/java/com/nadavramon/job_tracker/enums/Status.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/enums/Status.java
@@ -1,0 +1,10 @@
+package com.nadavramon.job_tracker.enums;
+
+public enum Status {
+    APPLIED,
+    SCREENING,
+    INTERVIEWING,
+    OFFER,
+    REJECTED,
+    WITHDRAWN
+}

--- a/backend/src/main/java/com/nadavramon/job_tracker/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.nadavramon.job_tracker.exception;
 import com.nadavramon.job_tracker.dto.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -46,6 +47,15 @@ public class GlobalExceptionHandler {
                 ex.getMessage()
         );
         return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidFormat(HttpMessageNotReadableException ex) {
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "Invalid request format: " + ex.getMostSpecificCause().getMessage()
+        );
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/backend/src/test/java/com/nadavramon/job_tracker/controller/ApplicationControllerTest.java
+++ b/backend/src/test/java/com/nadavramon/job_tracker/controller/ApplicationControllerTest.java
@@ -7,6 +7,8 @@ import com.nadavramon.job_tracker.config.SecurityConfig;
 import com.nadavramon.job_tracker.dto.ApplicationRequest;
 import com.nadavramon.job_tracker.entity.Application;
 import com.nadavramon.job_tracker.entity.User;
+import com.nadavramon.job_tracker.enums.JobType;
+import com.nadavramon.job_tracker.enums.Status;
 import com.nadavramon.job_tracker.repository.ApplicationRepository;
 import com.nadavramon.job_tracker.repository.UserRepository;
 import com.nadavramon.job_tracker.service.JwtService;
@@ -155,8 +157,8 @@ public class ApplicationControllerTest {
         request.setCompanyName("Google");
         request.setJobRole("Developer");
         request.setLocation("Tel Aviv");
-        request.setStatus("APPLIED");
-        request.setJobType("FULL_TIME");
+        request.setStatus(Status.APPLIED);
+        request.setJobType(JobType.FULL_TIME);
         request.setAppliedDate(java.time.LocalDate.now());
         request.setWebsiteLink("https://google.com");
 


### PR DESCRIPTION
## Summary
Replaces string fields with type-safe enums for status and jobType in applications.

## Changes
- Created `Status` enum: APPLIED, SCREENING, INTERVIEWING, OFFER, REJECTED, WITHDRAWN
- Created `JobType` enum: FULL_TIME, PART_TIME, CONTRACT, INTERNSHIP
- Updated Application entity to use @Enumerated(EnumType.STRING)
- Updated ApplicationRequest DTO with @NotNull validation for enum fields
- Added HttpMessageNotReadableException handler for invalid enum values (returns 400)
- Updated tests to use enum values

## Benefits
- Type safety - prevents invalid status/jobType values
- Clear API contract - clients know exactly which values are accepted
- Better error messages - invalid enum values return helpful error with valid options