### PR TITLE
Refactor: Add application service layer and clean up API responses

### DIFF
--- a/backend/src/main/java/com/nadavramon/job_tracker/controller/ApplicationController.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/controller/ApplicationController.java
@@ -1,14 +1,9 @@
 package com.nadavramon.job_tracker.controller;
 
 import com.nadavramon.job_tracker.dto.ApplicationRequest;
-import com.nadavramon.job_tracker.entity.Application;
-import com.nadavramon.job_tracker.entity.User;
-import com.nadavramon.job_tracker.exception.AccessDeniedException;
-import com.nadavramon.job_tracker.exception.ResourceNotFoundException;
-import com.nadavramon.job_tracker.repository.ApplicationRepository;
-import com.nadavramon.job_tracker.repository.UserRepository;
+import com.nadavramon.job_tracker.dto.ApplicationResponse;
+import com.nadavramon.job_tracker.service.ApplicationService;
 import jakarta.validation.Valid;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,101 +13,35 @@ import java.util.UUID;
 @RequestMapping("/applications")
 public class ApplicationController {
 
-    private final ApplicationRepository applicationRepository;
-    private final UserRepository userRepository;
+    private final ApplicationService applicationService;
 
-    public ApplicationController(ApplicationRepository applicationRepository, UserRepository userRepository) {
-        this.applicationRepository = applicationRepository;
-        this.userRepository = userRepository;
+    public ApplicationController(ApplicationService applicationService) {
+        this.applicationService = applicationService;
     }
 
     @GetMapping
-    public List<Application> getAllApplications() {
-        return applicationRepository.findByUser(getCurrentUser());
+    public List<ApplicationResponse> getAllApplications() {
+        return applicationService.getAllApplicationsByUser();
     }
 
     @GetMapping("/{id}")
-    public Application getApplicationById(@PathVariable UUID id) {
-        Application application = applicationRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("Application not found"));
-
-        if (!application.getUser().getId().equals(getCurrentUser().getId()))
-            throw new AccessDeniedException("Access denied");
-        return application;
+    public ApplicationResponse getApplication(@PathVariable UUID id) {
+        return applicationService.getApplicationByUser(id);
     }
 
     @PostMapping
-    public Application createApplication(@Valid @RequestBody ApplicationRequest request) {
-        Application application = new Application();
-
-        application.setCompanyName(request.getCompanyName());
-        application.setJobRole(request.getJobRole());
-        application.setLocation(request.getLocation());
-        application.setStatus(request.getStatus());
-        application.setJobType(request.getJobType());
-        application.setAppliedDate(request.getAppliedDate());
-        application.setWebsiteLink(request.getWebsiteLink());
-        application.setUsername(request.getUsername());
-        application.setPassword(request.getPassword());
-
-        application.setUser(getCurrentUser());
-        return applicationRepository.save(application);
+    public ApplicationResponse createApplication(@Valid @RequestBody ApplicationRequest request) {
+        return applicationService.createApplicationByUser(request);
     }
 
     @PatchMapping("/{id}")
-    public Application updateApplication(@PathVariable UUID id, @Valid @RequestBody ApplicationRequest request) {
-        Application application = applicationRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("Application not found"));
-
-        if (!application.getUser().getId().equals(getCurrentUser().getId())) {
-            throw new AccessDeniedException("Access denied");
-        }
-
-        if (request.getCompanyName() != null)
-            application.setCompanyName(request.getCompanyName());
-
-        if (request.getLocation() != null)
-            application.setLocation(request.getLocation());
-
-        if (request.getJobType() != null)
-            application.setJobType(request.getJobType());
-
-        if (request.getJobRole() != null)
-            application.setJobRole(request.getJobRole());
-
-        if (request.getStatus() != null)
-            application.setStatus(request.getStatus());
-
-        if (request.getAppliedDate() != null)
-            application.setAppliedDate(request.getAppliedDate());
-
-        if (request.getWebsiteLink() != null)
-            application.setWebsiteLink(request.getWebsiteLink());
-
-        if (request.getUsername() != null)
-            application.setUsername(request.getUsername());
-
-        if (request.getPassword() != null)
-            application.setPassword(request.getPassword());
-
-        return applicationRepository.save(application);
+    public ApplicationResponse updateApplication(@PathVariable UUID id
+            , @Valid @RequestBody ApplicationRequest request) {
+        return applicationService.updateApplicationByUser(id, request);
     }
 
     @DeleteMapping("/{id}")
     public void deleteApplication(@PathVariable UUID id) {
-        Application application = applicationRepository.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("Application not found"));
-
-        if (!application.getUser().getId().equals(getCurrentUser().getId())) {
-            throw new AccessDeniedException("Access denied");
-        }
-
-        applicationRepository.deleteById(id);
-    }
-
-    private User getCurrentUser() {
-        String username = SecurityContextHolder.getContext().getAuthentication().getName();
-        return userRepository.findByUsername(username)
-                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+        applicationService.deleteApplicationByUser(id);
     }
 }

--- a/backend/src/main/java/com/nadavramon/job_tracker/dto/ApplicationResponse.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/dto/ApplicationResponse.java
@@ -1,0 +1,126 @@
+package com.nadavramon.job_tracker.dto;
+
+import com.nadavramon.job_tracker.enums.JobType;
+import com.nadavramon.job_tracker.enums.Status;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public class ApplicationResponse {
+
+    private UUID id;
+    private String companyName;
+    private JobType jobType;
+    private String location;
+    private String jobRole;
+    private LocalDate appliedDate;
+    private Status status;
+    private LocalDate statusChangedDate;
+    private String websiteLink;
+    private String username;
+    private String password;
+
+    public ApplicationResponse(UUID id, String companyName, JobType jobType, String location, String jobRole
+            , LocalDate appliedDate, Status status, LocalDate statusChangedDate, String websiteLink, String username
+            , String password) {
+        this.id = id;
+        this.companyName = companyName;
+        this.jobType = jobType;
+        this.location = location;
+        this.jobRole = jobRole;
+        this.appliedDate = appliedDate;
+        this.status = status;
+        this.statusChangedDate = statusChangedDate;
+        this.websiteLink = websiteLink;
+        this.username = username;
+        this.password = password;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
+    }
+
+    public JobType getJobType() {
+        return jobType;
+    }
+
+    public void setJobType(JobType jobType) {
+        this.jobType = jobType;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public String getJobRole() {
+        return jobRole;
+    }
+
+    public void setJobRole(String jobRole) {
+        this.jobRole = jobRole;
+    }
+
+    public LocalDate getAppliedDate() {
+        return appliedDate;
+    }
+
+    public void setAppliedDate(LocalDate appliedDate) {
+        this.appliedDate = appliedDate;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public LocalDate getStatusChangedDate() {
+        return statusChangedDate;
+    }
+
+    public void setStatusChangedDate(LocalDate statusChangedDate) {
+        this.statusChangedDate = statusChangedDate;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getWebsiteLink() {
+        return websiteLink;
+    }
+
+    public void setWebsiteLink(String websiteLink) {
+        this.websiteLink = websiteLink;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/backend/src/main/java/com/nadavramon/job_tracker/service/ApplicationService.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/service/ApplicationService.java
@@ -1,0 +1,135 @@
+package com.nadavramon.job_tracker.service;
+
+import com.nadavramon.job_tracker.dto.ApplicationRequest;
+import com.nadavramon.job_tracker.dto.ApplicationResponse;
+import com.nadavramon.job_tracker.entity.Application;
+import com.nadavramon.job_tracker.entity.User;
+import com.nadavramon.job_tracker.exception.AccessDeniedException;
+import com.nadavramon.job_tracker.exception.ResourceNotFoundException;
+import com.nadavramon.job_tracker.repository.ApplicationRepository;
+import com.nadavramon.job_tracker.repository.UserRepository;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class ApplicationService {
+
+    private final ApplicationRepository applicationRepository;
+    private final UserRepository userRepository;
+
+    public ApplicationService(ApplicationRepository applicationRepository, UserRepository userRepository) {
+        this.applicationRepository = applicationRepository;
+        this.userRepository = userRepository;
+    }
+
+    public List<ApplicationResponse> getAllApplicationsByUser() {
+        List<Application> applications = applicationRepository.findByUser(getCurrentUser());
+        List<ApplicationResponse> responses = new ArrayList<>();
+
+        for (Application application : applications) {
+            responses.add(toResponse(application));
+        }
+        return responses;
+    }
+
+    public ApplicationResponse getApplicationByUser(UUID id) {
+        Application application = applicationRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("User's application not found"));
+
+        if (!application.getUser().getId().equals(getCurrentUser().getId()))
+            throw new AccessDeniedException("Access denied");
+        return toResponse(application);
+    }
+
+    public ApplicationResponse createApplicationByUser(ApplicationRequest request) {
+        Application application = new Application();
+
+        application.setCompanyName(request.getCompanyName());
+        application.setJobRole(request.getJobRole());
+        application.setLocation(request.getLocation());
+        application.setStatus(request.getStatus());
+        application.setJobType(request.getJobType());
+        application.setAppliedDate(request.getAppliedDate());
+        application.setWebsiteLink(request.getWebsiteLink());
+        application.setUsername(request.getUsername());
+        application.setPassword(request.getPassword());
+
+        application.setUser(getCurrentUser());
+        return toResponse(applicationRepository.save(application));
+    }
+
+    public ApplicationResponse updateApplicationByUser(UUID id, ApplicationRequest request) {
+        Application application = applicationRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Application not found"));
+
+        if (!application.getUser().getId().equals(getCurrentUser().getId())) {
+            throw new AccessDeniedException("Access denied");
+        }
+
+        if (request.getCompanyName() != null)
+            application.setCompanyName(request.getCompanyName());
+
+        if (request.getLocation() != null)
+            application.setLocation(request.getLocation());
+
+        if (request.getJobType() != null)
+            application.setJobType(request.getJobType());
+
+        if (request.getJobRole() != null)
+            application.setJobRole(request.getJobRole());
+
+        if (request.getStatus() != null)
+            application.setStatus(request.getStatus());
+
+        if (request.getAppliedDate() != null)
+            application.setAppliedDate(request.getAppliedDate());
+
+        if (request.getWebsiteLink() != null)
+            application.setWebsiteLink(request.getWebsiteLink());
+
+        if (request.getUsername() != null)
+            application.setUsername(request.getUsername());
+
+        if (request.getPassword() != null)
+            application.setPassword(request.getPassword());
+
+        return toResponse(applicationRepository.save(application));
+    }
+
+    public void deleteApplicationByUser(UUID id) {
+        Application application = applicationRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Application not found"));
+
+        if (!application.getUser().getId().equals(getCurrentUser().getId())) {
+            throw new AccessDeniedException("Access denied");
+        }
+
+        applicationRepository.deleteById(id);
+    }
+
+    private User getCurrentUser() {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+    }
+
+    private ApplicationResponse toResponse(Application application) {
+        return new ApplicationResponse(
+                application.getId(),
+                application.getCompanyName(),
+                application.getJobType(),
+                application.getLocation(),
+                application.getJobRole(),
+                application.getAppliedDate(),
+                application.getStatus(),
+                application.getStatusChangedDate(),
+                application.getWebsiteLink(),
+                application.getUsername(),
+                application.getPassword()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Introduces a service layer for applications and removes the nested user object from API responses.

## Changes
- Created `ApplicationService` to handle business logic and entity-to-DTO mapping
- Created `ApplicationResponse` DTO to control API output shape
- Refactored `ApplicationController` to be thin and delegate to service
- Updated controller tests to mock service layer instead of repositories

## API Changes
Application responses no longer include the nested `user` object. Before:
```json
{
  "id": "...",
  "companyName": "Google",
  "user": {
    "id": "...",
    "email": "...",
    "username": "..."
  }
}
```

After:
```json
{
  "id": "...",
  "companyName": "Google"
}
```

## Testing
- All existing tests updated and passing
- Manually verified with Postman