### PR TITLE
feat: add server-side pagination to GET /applications

### DIFF
--- a/backend/src/main/java/com/nadavramon/job_tracker/JobTrackerApplication.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/JobTrackerApplication.java
@@ -2,8 +2,12 @@ package com.nadavramon.job_tracker;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
 @SpringBootApplication
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 public class JobTrackerApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/nadavramon/job_tracker/controller/ApplicationController.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/controller/ApplicationController.java
@@ -2,11 +2,15 @@ package com.nadavramon.job_tracker.controller;
 
 import com.nadavramon.job_tracker.dto.ApplicationRequest;
 import com.nadavramon.job_tracker.dto.ApplicationResponse;
+import com.nadavramon.job_tracker.enums.Status;
 import com.nadavramon.job_tracker.service.ApplicationService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -20,8 +24,11 @@ public class ApplicationController {
     }
 
     @GetMapping
-    public List<ApplicationResponse> getAllApplications() {
-        return applicationService.getAllApplicationsByUser();
+    public Page<ApplicationResponse> getAllApplications(
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false) Status status,
+            @PageableDefault(size = 20, sort = "appliedDate", direction = Sort.Direction.DESC) Pageable pageable) {
+        return applicationService.getAllApplicationsByUser(search, status, pageable);
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/com/nadavramon/job_tracker/repository/ApplicationRepository.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/repository/ApplicationRepository.java
@@ -2,11 +2,26 @@ package com.nadavramon.job_tracker.repository;
 
 import com.nadavramon.job_tracker.entity.Application;
 import com.nadavramon.job_tracker.entity.User;
+import com.nadavramon.job_tracker.enums.Status;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface ApplicationRepository extends JpaRepository<Application, UUID> {
     List<Application> findByUser(User user);
+
+    @Query("SELECT a FROM Application a WHERE a.user = :user " +
+           "AND (:search IS NULL OR LOWER(a.companyName) LIKE LOWER(CONCAT('%', :search, '%'))) " +
+           "AND (:status IS NULL OR a.status = :status)")
+    Page<Application> findByUserWithFilters(
+            @Param("user") User user,
+            @Param("search") String search,
+            @Param("status") Status status,
+            Pageable pageable
+    );
 }

--- a/backend/src/main/java/com/nadavramon/job_tracker/service/ApplicationService.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/service/ApplicationService.java
@@ -4,16 +4,17 @@ import com.nadavramon.job_tracker.dto.ApplicationRequest;
 import com.nadavramon.job_tracker.dto.ApplicationResponse;
 import com.nadavramon.job_tracker.entity.Application;
 import com.nadavramon.job_tracker.entity.User;
+import com.nadavramon.job_tracker.enums.Status;
 import com.nadavramon.job_tracker.exception.AccessDeniedException;
 import com.nadavramon.job_tracker.exception.ResourceNotFoundException;
 import com.nadavramon.job_tracker.repository.ApplicationRepository;
 import com.nadavramon.job_tracker.repository.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -27,14 +28,10 @@ public class ApplicationService {
         this.userRepository = userRepository;
     }
 
-    public List<ApplicationResponse> getAllApplicationsByUser() {
-        List<Application> applications = applicationRepository.findByUser(getCurrentUser());
-        List<ApplicationResponse> responses = new ArrayList<>();
-
-        for (Application application : applications) {
-            responses.add(toResponse(application));
-        }
-        return responses;
+    public Page<ApplicationResponse> getAllApplicationsByUser(String search, Status status, Pageable pageable) {
+        return applicationRepository
+                .findByUserWithFilters(getCurrentUser(), search, status, pageable)
+                .map(this::toResponse);
     }
 
     public ApplicationResponse getApplicationByUser(UUID id) {

--- a/backend/src/test/java/com/nadavramon/job_tracker/controller/ApplicationControllerTest.java
+++ b/backend/src/test/java/com/nadavramon/job_tracker/controller/ApplicationControllerTest.java
@@ -21,6 +21,10 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -51,18 +55,19 @@ public class ApplicationControllerTest {
 
     @Test
     @WithMockUser
-    void getAllApplications_ReturnsEmptyList_WhenNoApplicationsExist() throws Exception {
-        when(applicationService.getAllApplicationsByUser()).thenReturn(List.of());
+    void getAllApplications_ReturnsEmptyPage_WhenNoApplicationsExist() throws Exception {
+        when(applicationService.getAllApplicationsByUser(any(), any(), any(Pageable.class)))
+                .thenReturn(Page.empty());
 
         mockMvc.perform(get("/applications"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$").isArray())
-                .andExpect(jsonPath("$").isEmpty());
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content").isEmpty());
     }
 
     @Test
     @WithMockUser
-    void getAllApplications_ReturnsList_WhenApplicationsExist() throws Exception {
+    void getAllApplications_ReturnsPage_WhenApplicationsExist() throws Exception {
         ApplicationResponse app1 = new ApplicationResponse(
                 UUID.randomUUID(), "Google", JobType.FULL_TIME, "Tel Aviv", "Developer",
                 LocalDate.now(), Status.APPLIED, null, "https://google.com", null, null
@@ -72,14 +77,15 @@ public class ApplicationControllerTest {
                 LocalDate.now(), Status.APPLIED, null, "https://microsoft.com", null, null
         );
 
-        when(applicationService.getAllApplicationsByUser()).thenReturn(List.of(app1, app2));
+        when(applicationService.getAllApplicationsByUser(any(), any(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(app1, app2)));
 
         mockMvc.perform(get("/applications"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$").isArray())
-                .andExpect(jsonPath("$.length()").value(2))
-                .andExpect(jsonPath("$[0].companyName").value("Google"))
-                .andExpect(jsonPath("$[1].companyName").value("Microsoft"));
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content[0].companyName").value("Google"))
+                .andExpect(jsonPath("$.content[1].companyName").value("Microsoft"));
     }
 
     @Test


### PR DESCRIPTION
- ApplicationRepository: add findByUserWithFilters JPQL query with optional search (ILIKE on companyName) and status filter, using Pageable
- ApplicationService: getAllApplicationsByUser now returns Page<ApplicationResponse>
  and accepts search, status, Pageable params
- ApplicationController: GET /applications accepts ?page, ?size, ?sort, ?search, ?status — defaults to page=0, size=20, sort=appliedDate,desc
- JobTrackerApplication: add @EnableSpringDataWebSupport(VIA_DTO) for stable Page JSON serialization (content + page metadata object)
- ApplicationControllerTest: update two list tests to assert $.content