### PR TITLE
feat: add GET /applications/stats endpoint

### DIFF
--- a/backend/src/main/java/com/nadavramon/job_tracker/controller/ApplicationController.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/controller/ApplicationController.java
@@ -2,6 +2,7 @@ package com.nadavramon.job_tracker.controller;
 
 import com.nadavramon.job_tracker.dto.ApplicationRequest;
 import com.nadavramon.job_tracker.dto.ApplicationResponse;
+import com.nadavramon.job_tracker.dto.ApplicationStatsResponse;
 import com.nadavramon.job_tracker.enums.Status;
 import com.nadavramon.job_tracker.service.ApplicationService;
 import jakarta.validation.Valid;
@@ -29,6 +30,11 @@ public class ApplicationController {
             @RequestParam(required = false) Status status,
             @PageableDefault(size = 20, sort = "appliedDate", direction = Sort.Direction.DESC) Pageable pageable) {
         return applicationService.getAllApplicationsByUser(search, status, pageable);
+    }
+
+    @GetMapping("/stats")
+    public ApplicationStatsResponse getStats() {
+        return applicationService.getApplicationStats();
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/com/nadavramon/job_tracker/dto/ApplicationStatsResponse.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/dto/ApplicationStatsResponse.java
@@ -1,0 +1,54 @@
+package com.nadavramon.job_tracker.dto;
+
+import com.nadavramon.job_tracker.enums.Status;
+
+import java.util.List;
+import java.util.Map;
+
+public class ApplicationStatsResponse {
+
+    private int totalApplications;
+    private Map<Status, Long> statusBreakdown;
+    private List<MonthlyCount> monthlyApplications;
+    private double responseRate;
+
+    public ApplicationStatsResponse(int totalApplications, Map<Status, Long> statusBreakdown,
+                                    List<MonthlyCount> monthlyApplications, double responseRate) {
+        this.totalApplications = totalApplications;
+        this.statusBreakdown = statusBreakdown;
+        this.monthlyApplications = monthlyApplications;
+        this.responseRate = responseRate;
+    }
+
+    public int getTotalApplications() {
+        return totalApplications;
+    }
+
+    public void setTotalApplications(int totalApplications) {
+        this.totalApplications = totalApplications;
+    }
+
+    public Map<Status, Long> getStatusBreakdown() {
+        return statusBreakdown;
+    }
+
+    public void setStatusBreakdown(Map<Status, Long> statusBreakdown) {
+        this.statusBreakdown = statusBreakdown;
+    }
+
+    public List<MonthlyCount> getMonthlyApplications() {
+        return monthlyApplications;
+    }
+
+    public void setMonthlyApplications(List<MonthlyCount> monthlyApplications) {
+        this.monthlyApplications = monthlyApplications;
+    }
+
+    public double getResponseRate() {
+        return responseRate;
+    }
+
+    public void setResponseRate(double responseRate) {
+        this.responseRate = responseRate;
+    }
+}

--- a/backend/src/main/java/com/nadavramon/job_tracker/dto/MonthlyCount.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/dto/MonthlyCount.java
@@ -1,0 +1,28 @@
+package com.nadavramon.job_tracker.dto;
+
+public class MonthlyCount {
+
+    private String month;
+    private long count;
+
+    public MonthlyCount(String month, long count) {
+        this.month = month;
+        this.count = count;
+    }
+
+    public String getMonth() {
+        return month;
+    }
+
+    public void setMonth(String month) {
+        this.month = month;
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    public void setCount(long count) {
+        this.count = count;
+    }
+}

--- a/backend/src/main/java/com/nadavramon/job_tracker/service/ApplicationService.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/service/ApplicationService.java
@@ -2,6 +2,8 @@ package com.nadavramon.job_tracker.service;
 
 import com.nadavramon.job_tracker.dto.ApplicationRequest;
 import com.nadavramon.job_tracker.dto.ApplicationResponse;
+import com.nadavramon.job_tracker.dto.ApplicationStatsResponse;
+import com.nadavramon.job_tracker.dto.MonthlyCount;
 import com.nadavramon.job_tracker.entity.Application;
 import com.nadavramon.job_tracker.entity.User;
 import com.nadavramon.job_tracker.enums.Status;
@@ -14,7 +16,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -96,6 +104,49 @@ public class ApplicationService {
             application.setPassword(request.getPassword());
 
         return toResponse(applicationRepository.save(application));
+    }
+
+    public ApplicationStatsResponse getApplicationStats() {
+        List<Application> applications = applicationRepository.findByUser(getCurrentUser());
+
+        int total = applications.size();
+
+        // Status breakdown — initialize all statuses to 0
+        Map<Status, Long> statusBreakdown = new EnumMap<>(Status.class);
+        for (Status s : Status.values()) {
+            statusBreakdown.put(s, 0L);
+        }
+        for (Application app : applications) {
+            statusBreakdown.merge(app.getStatus(), 1L, Long::sum);
+        }
+
+        // Response rate: applications that received any response (not APPLIED, not WITHDRAWN)
+        long responded = applications.stream()
+                .filter(a -> a.getStatus() == Status.SCREENING
+                        || a.getStatus() == Status.INTERVIEWING
+                        || a.getStatus() == Status.OFFER
+                        || a.getStatus() == Status.REJECTED)
+                .count();
+        double responseRate = total == 0 ? 0.0
+                : Math.round(responded * 1000.0 / total) / 10.0;
+
+        // Monthly applications — last 6 months (inclusive of current month)
+        LocalDate now = LocalDate.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM");
+        List<MonthlyCount> monthly = new ArrayList<>();
+        for (int i = 5; i >= 0; i--) {
+            LocalDate month = now.minusMonths(i);
+            int year = month.getYear();
+            int mo = month.getMonthValue();
+            long count = applications.stream()
+                    .filter(a -> a.getAppliedDate() != null
+                            && a.getAppliedDate().getYear() == year
+                            && a.getAppliedDate().getMonthValue() == mo)
+                    .count();
+            monthly.add(new MonthlyCount(month.format(formatter), count));
+        }
+
+        return new ApplicationStatsResponse(total, statusBreakdown, monthly, responseRate);
     }
 
     public void deleteApplicationByUser(UUID id) {

--- a/backend/src/test/java/com/nadavramon/job_tracker/controller/ApplicationControllerTest.java
+++ b/backend/src/test/java/com/nadavramon/job_tracker/controller/ApplicationControllerTest.java
@@ -6,6 +6,8 @@ import com.nadavramon.job_tracker.config.JwtAuthenticationFilter;
 import com.nadavramon.job_tracker.config.SecurityConfig;
 import com.nadavramon.job_tracker.dto.ApplicationRequest;
 import com.nadavramon.job_tracker.dto.ApplicationResponse;
+import com.nadavramon.job_tracker.dto.ApplicationStatsResponse;
+import com.nadavramon.job_tracker.dto.MonthlyCount;
 import com.nadavramon.job_tracker.enums.JobType;
 import com.nadavramon.job_tracker.enums.Status;
 import com.nadavramon.job_tracker.exception.AccessDeniedException;
@@ -26,7 +28,9 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -190,5 +194,53 @@ public class ApplicationControllerTest {
         mockMvc.perform(delete("/applications/" + appId))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.message").value("Access denied"));
+    }
+
+    @Test
+    @WithMockUser
+    void getStats_ReturnsStats_WhenAuthenticated() throws Exception {
+        Map<Status, Long> breakdown = new EnumMap<>(Status.class);
+        for (Status s : Status.values()) breakdown.put(s, 0L);
+        breakdown.put(Status.APPLIED, 3L);
+        breakdown.put(Status.REJECTED, 1L);
+
+        List<MonthlyCount> monthly = List.of(new MonthlyCount("2026-02", 4L));
+        ApplicationStatsResponse stats = new ApplicationStatsResponse(4, breakdown, monthly, 25.0);
+
+        when(applicationService.getApplicationStats()).thenReturn(stats);
+
+        mockMvc.perform(get("/applications/stats"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalApplications").value(4))
+                .andExpect(jsonPath("$.responseRate").value(25.0))
+                .andExpect(jsonPath("$.statusBreakdown.APPLIED").value(3))
+                .andExpect(jsonPath("$.statusBreakdown.REJECTED").value(1))
+                .andExpect(jsonPath("$.monthlyApplications").isArray())
+                .andExpect(jsonPath("$.monthlyApplications[0].month").value("2026-02"))
+                .andExpect(jsonPath("$.monthlyApplications[0].count").value(4));
+    }
+
+    @Test
+    @WithMockUser
+    void getStats_ReturnsZeroStats_WhenNoApplications() throws Exception {
+        Map<Status, Long> breakdown = new EnumMap<>(Status.class);
+        for (Status s : Status.values()) breakdown.put(s, 0L);
+
+        ApplicationStatsResponse stats = new ApplicationStatsResponse(0, breakdown, List.of(), 0.0);
+
+        when(applicationService.getApplicationStats()).thenReturn(stats);
+
+        mockMvc.perform(get("/applications/stats"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalApplications").value(0))
+                .andExpect(jsonPath("$.responseRate").value(0.0))
+                .andExpect(jsonPath("$.monthlyApplications").isArray())
+                .andExpect(jsonPath("$.monthlyApplications").isEmpty());
+    }
+
+    @Test
+    void getStats_Returns403_WhenNotAuthenticated() throws Exception {
+        mockMvc.perform(get("/applications/stats"))
+                .andExpect(status().isForbidden());
     }
 }


### PR DESCRIPTION
- MonthlyCount DTO: month (yyyy-MM) and count
- ApplicationStatsResponse DTO: totalApplications, statusBreakdown (all statuses initialized to 0), monthlyApplications (last 6 months), responseRate
- ApplicationService: getApplicationStats() computes stats in-memory from user application list
- ApplicationController: GET /applications/stats placed before /{id} to prevent path variable capture
- ApplicationControllerTest: 3 new tests (success, zero state, unauthenticated 403)