### PR TITLE
feat: add GET/PATCH/DELETE /me user profile endpoints

### DIFF
--- a/backend/src/main/java/com/nadavramon/job_tracker/controller/UserController.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/controller/UserController.java
@@ -1,0 +1,33 @@
+package com.nadavramon.job_tracker.controller;
+
+import com.nadavramon.job_tracker.dto.UpdateProfileRequest;
+import com.nadavramon.job_tracker.dto.UserProfileResponse;
+import com.nadavramon.job_tracker.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/me")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping
+    public UserProfileResponse getProfile() {
+        return userService.getUserProfile();
+    }
+
+    @PatchMapping
+    public UserProfileResponse updateProfile(@Valid @RequestBody UpdateProfileRequest request) {
+        return userService.updateUserProfile(request);
+    }
+
+    @DeleteMapping
+    public void deleteAccount() {
+        userService.deleteCurrentUser();
+    }
+}

--- a/backend/src/main/java/com/nadavramon/job_tracker/dto/UpdateProfileRequest.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/dto/UpdateProfileRequest.java
@@ -1,0 +1,51 @@
+package com.nadavramon.job_tracker.dto;
+
+import com.nadavramon.job_tracker.enums.ThemePreference;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+
+public class UpdateProfileRequest {
+
+    @Email
+    private String email;
+
+    @Size(min = 3, max = 50)
+    private String username;
+
+    @Size(min = 8)
+    private String password;
+
+    private ThemePreference themePreference;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public ThemePreference getThemePreference() {
+        return themePreference;
+    }
+
+    public void setThemePreference(ThemePreference themePreference) {
+        this.themePreference = themePreference;
+    }
+}

--- a/backend/src/main/java/com/nadavramon/job_tracker/dto/UserProfileResponse.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/dto/UserProfileResponse.java
@@ -1,0 +1,52 @@
+package com.nadavramon.job_tracker.dto;
+
+import com.nadavramon.job_tracker.enums.ThemePreference;
+
+import java.util.UUID;
+
+public class UserProfileResponse {
+
+    private UUID id;
+    private String email;
+    private String username;
+    private ThemePreference themePreference;
+
+    public UserProfileResponse(UUID id, String email, String username, ThemePreference themePreference) {
+        this.id = id;
+        this.email = email;
+        this.username = username;
+        this.themePreference = themePreference;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public ThemePreference getThemePreference() {
+        return themePreference;
+    }
+
+    public void setThemePreference(ThemePreference themePreference) {
+        this.themePreference = themePreference;
+    }
+}

--- a/backend/src/main/java/com/nadavramon/job_tracker/entity/User.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/entity/User.java
@@ -3,11 +3,14 @@ package com.nadavramon.job_tracker.entity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.nadavramon.job_tracker.enums.ThemePreference;
 import jakarta.persistence.*;
+import org.hibernate.annotations.SQLRestriction;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
 @Table(name = "users")
+@SQLRestriction("deleted_at IS NULL")
 public class User {
 
     @Id
@@ -60,11 +63,21 @@ public class User {
         this.password = password;
     }
 
+    private LocalDateTime deletedAt;
+
     public ThemePreference getThemePreference() {
         return themePreference;
     }
 
     public void setThemePreference(ThemePreference themePreference) {
         this.themePreference = themePreference;
+    }
+
+    public LocalDateTime getDeletedAt() {
+        return deletedAt;
+    }
+
+    public void setDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
     }
 }

--- a/backend/src/main/java/com/nadavramon/job_tracker/repository/ApplicationRepository.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/repository/ApplicationRepository.java
@@ -9,6 +9,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.Modifying;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -24,4 +28,9 @@ public interface ApplicationRepository extends JpaRepository<Application, UUID> 
             @Param("status") Status status,
             Pageable pageable
     );
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Application a SET a.deletedAt = :now WHERE a.user = :user AND a.deletedAt IS NULL")
+    void softDeleteAllByUser(@Param("user") User user, @Param("now") LocalDateTime now);
 }

--- a/backend/src/main/java/com/nadavramon/job_tracker/service/UserService.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/service/UserService.java
@@ -1,0 +1,80 @@
+package com.nadavramon.job_tracker.service;
+
+import com.nadavramon.job_tracker.dto.UpdateProfileRequest;
+import com.nadavramon.job_tracker.dto.UserProfileResponse;
+import com.nadavramon.job_tracker.entity.User;
+import com.nadavramon.job_tracker.exception.DuplicateResourceException;
+import com.nadavramon.job_tracker.exception.ResourceNotFoundException;
+import com.nadavramon.job_tracker.repository.ApplicationRepository;
+import com.nadavramon.job_tracker.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final ApplicationRepository applicationRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository userRepository, ApplicationRepository applicationRepository,
+                       PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.applicationRepository = applicationRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public UserProfileResponse getUserProfile() {
+        return toResponse(getCurrentUser());
+    }
+
+    public UserProfileResponse updateUserProfile(UpdateProfileRequest request) {
+        User user = getCurrentUser();
+
+        if (request.getEmail() != null && !request.getEmail().equals(user.getEmail())) {
+            if (userRepository.existsByEmail(request.getEmail()))
+                throw new DuplicateResourceException("Email already taken");
+            user.setEmail(request.getEmail());
+        }
+
+        if (request.getUsername() != null && !request.getUsername().equals(user.getUsername())) {
+            if (userRepository.existsByUsername(request.getUsername()))
+                throw new DuplicateResourceException("Username already taken");
+            user.setUsername(request.getUsername());
+        }
+
+        if (request.getPassword() != null) {
+            user.setPassword(passwordEncoder.encode(request.getPassword()));
+        }
+
+        if (request.getThemePreference() != null) {
+            user.setThemePreference(request.getThemePreference());
+        }
+
+        return toResponse(userRepository.save(user));
+    }
+
+    @Transactional
+    public void deleteCurrentUser() {
+        User user = getCurrentUser();
+        LocalDateTime now = LocalDateTime.now();
+        applicationRepository.softDeleteAllByUser(user, now);
+        user.setDeletedAt(now);
+        userRepository.save(user);
+    }
+
+    private User getCurrentUser() {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+    }
+
+    private UserProfileResponse toResponse(User user) {
+        return new UserProfileResponse(user.getId(), user.getEmail(), user.getUsername(),
+                user.getThemePreference());
+    }
+}

--- a/backend/src/test/java/com/nadavramon/job_tracker/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/nadavramon/job_tracker/controller/UserControllerTest.java
@@ -1,0 +1,140 @@
+package com.nadavramon.job_tracker.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nadavramon.job_tracker.config.JwtAuthenticationFilter;
+import com.nadavramon.job_tracker.config.SecurityConfig;
+import com.nadavramon.job_tracker.dto.UpdateProfileRequest;
+import com.nadavramon.job_tracker.dto.UserProfileResponse;
+import com.nadavramon.job_tracker.enums.ThemePreference;
+import com.nadavramon.job_tracker.exception.DuplicateResourceException;
+import com.nadavramon.job_tracker.service.JwtService;
+import com.nadavramon.job_tracker.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @Test
+    @WithMockUser
+    void getProfile_ReturnsProfile_WhenAuthenticated() throws Exception {
+        UserProfileResponse profile = new UserProfileResponse(
+                UUID.randomUUID(), "test@test.com", "testuser", ThemePreference.SYSTEM
+        );
+        when(userService.getUserProfile()).thenReturn(profile);
+
+        mockMvc.perform(get("/me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("test@test.com"))
+                .andExpect(jsonPath("$.username").value("testuser"))
+                .andExpect(jsonPath("$.themePreference").value("SYSTEM"));
+    }
+
+    @Test
+    void getProfile_Returns403_WhenNotAuthenticated() throws Exception {
+        mockMvc.perform(get("/me"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser
+    void updateProfile_ReturnsUpdatedProfile_WhenValidRequest() throws Exception {
+        UpdateProfileRequest request = new UpdateProfileRequest();
+        request.setThemePreference(ThemePreference.DARK);
+
+        UserProfileResponse updated = new UserProfileResponse(
+                UUID.randomUUID(), "test@test.com", "testuser", ThemePreference.DARK
+        );
+        when(userService.updateUserProfile(any(UpdateProfileRequest.class))).thenReturn(updated);
+
+        mockMvc.perform(patch("/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.themePreference").value("DARK"));
+    }
+
+    @Test
+    @WithMockUser
+    void updateProfile_ReturnsBadRequest_WhenEmailInvalid() throws Exception {
+        UpdateProfileRequest request = new UpdateProfileRequest();
+        request.setEmail("not-an-email");
+
+        mockMvc.perform(patch("/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @Test
+    @WithMockUser
+    void updateProfile_ReturnsBadRequest_WhenPasswordTooShort() throws Exception {
+        UpdateProfileRequest request = new UpdateProfileRequest();
+        request.setPassword("short");
+
+        mockMvc.perform(patch("/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @Test
+    @WithMockUser
+    void updateProfile_ReturnsConflict_WhenEmailAlreadyTaken() throws Exception {
+        UpdateProfileRequest request = new UpdateProfileRequest();
+        request.setEmail("taken@test.com");
+
+        when(userService.updateUserProfile(any(UpdateProfileRequest.class)))
+                .thenThrow(new DuplicateResourceException("Email already taken"));
+
+        mockMvc.perform(patch("/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("Email already taken"));
+    }
+
+    @Test
+    @WithMockUser
+    void deleteAccount_ReturnsSuccess_WhenAuthenticated() throws Exception {
+        doNothing().when(userService).deleteCurrentUser();
+
+        mockMvc.perform(delete("/me"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void deleteAccount_Returns403_WhenNotAuthenticated() throws Exception {
+        mockMvc.perform(delete("/me"))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
- User entity: add deletedAt field + @SQLRestriction to auto-exclude soft-deleted users from all JPA queries (auth, lookups)
- ApplicationRepository: softDeleteAllByUser bulk JPQL UPDATE for cascade
- UserProfileResponse DTO: id, email, username, themePreference
- UpdateProfileRequest DTO: optional email (@Email), username (@Size 3-50), password (@Size min 8), themePreference — null fields ignored (partial update)
- UserService: getUserProfile, updateUserProfile (skip-if-same checks before uniqueness validation), deleteCurrentUser (transactional cascade soft-delete)
- UserController: GET/PATCH/DELETE /me with @Valid on PATCH body
- UserControllerTest: 7 tests covering success, validation, conflict, 403