### PR TITLE
feat: add Modal and ConfirmDialog overlay components

### DIFF
--- a/frontend/components/ui/ConfirmDialog.tsx
+++ b/frontend/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import Modal from './Modal';
+import Button from './Button';
+
+interface ConfirmDialogProps {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+    title: string;
+    message: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    loading?: boolean;
+}
+
+export default function ConfirmDialog({
+    open,
+    onClose,
+    onConfirm,
+    title,
+    message,
+    confirmLabel = 'Delete',
+    cancelLabel = 'Cancel',
+    loading = false,
+}: ConfirmDialogProps) {
+    return (
+        <Modal open={open} onClose={onClose} title={title} maxWidth="max-w-sm">
+            <p className="text-sm text-[var(--muted-foreground)] mb-5">{message}</p>
+            <div className="flex justify-end gap-2">
+                <Button variant="secondary" size="sm" onClick={onClose} disabled={loading}>
+                    {cancelLabel}
+                </Button>
+                <Button variant="destructive" size="sm" onClick={onConfirm} loading={loading}>
+                    {confirmLabel}
+                </Button>
+            </div>
+        </Modal>
+    );
+}

--- a/frontend/components/ui/Modal.tsx
+++ b/frontend/components/ui/Modal.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import ReactDOM from 'react-dom';
+import { useSyncExternalStore } from 'react';
+
+interface ModalProps {
+    open: boolean;
+    onClose: () => void;
+    title?: string;
+    children: React.ReactNode;
+    /** Max width class, e.g. 'max-w-md' (default) or 'max-w-lg' */
+    maxWidth?: string;
+}
+
+function useIsMounted() {
+    return useSyncExternalStore(
+        () => () => {},
+        () => true,
+        () => false,
+    );
+}
+
+export default function Modal({ open, onClose, title, children, maxWidth = 'max-w-md' }: ModalProps) {
+    const mounted = useIsMounted();
+    const panelRef = useRef<HTMLDivElement>(null);
+
+    // Close on Escape
+    useEffect(() => {
+        if (!open) return;
+        const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+        document.addEventListener('keydown', handler);
+        return () => document.removeEventListener('keydown', handler);
+    }, [open, onClose]);
+
+    // Focus trap: move focus into panel when it opens
+    useEffect(() => {
+        if (!open) return;
+        const prev = document.activeElement as HTMLElement | null;
+        panelRef.current?.focus();
+        return () => { prev?.focus(); };
+    }, [open]);
+
+    // Prevent body scroll while open
+    useEffect(() => {
+        if (!open) return;
+        const original = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+        return () => { document.body.style.overflow = original; };
+    }, [open]);
+
+    if (!mounted || !open) return null;
+
+    const modal = (
+        <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={title ? 'modal-title' : undefined}
+            className="fixed inset-0 z-50 flex items-center justify-center p-4"
+        >
+            {/* Backdrop */}
+            <div
+                className="absolute inset-0 bg-black/50"
+                onClick={onClose}
+                aria-hidden="true"
+            />
+
+            {/* Panel */}
+            <div
+                ref={panelRef}
+                tabIndex={-1}
+                className={[
+                    'relative w-full rounded-xl shadow-xl outline-none',
+                    'bg-[var(--card)] text-[var(--card-foreground)]',
+                    'border border-[var(--border)]',
+                    maxWidth,
+                ].join(' ')}
+            >
+                {/* Header */}
+                {title && (
+                    <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-4">
+                        <h2 id="modal-title" className="text-base font-semibold">
+                            {title}
+                        </h2>
+                        <button
+                            onClick={onClose}
+                            aria-label="Close"
+                            className="rounded-md p-1 text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--muted)] transition-colors"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="h-4 w-4">
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                    </div>
+                )}
+
+                {/* Body */}
+                <div className="px-5 py-4">
+                    {children}
+                </div>
+            </div>
+        </div>
+    );
+
+    return ReactDOM.createPortal(modal, document.body);
+}


### PR DESCRIPTION
- Modal: portal-based dialog with backdrop, Escape-to-close, focus trap, body scroll lock, optional title + close button, configurable max-width
- ConfirmDialog: wraps Modal with cancel (secondary) + confirm (destructive) buttons and a loading state; ready for delete confirmations
- Both use CSS variables for full dark mode support
- useIsMounted via useSyncExternalStore (no setState-in-effect)