### PR TITLE
feat: add data display components (Badge, Card, Pagination, SearchInput)

### DIFF
--- a/frontend/components/ui/Badge.tsx
+++ b/frontend/components/ui/Badge.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { Status } from '@/types';
+
+// Generic variant badge
+export type BadgeVariant = 'default' | 'success' | 'warning' | 'danger' | 'info' | 'muted';
+
+const VARIANT_CLASSES: Record<BadgeVariant, string> = {
+    default:  'bg-blue-100   text-blue-800   dark:bg-blue-900/40  dark:text-blue-300',
+    success:  'bg-green-100  text-green-800  dark:bg-green-900/40 dark:text-green-300',
+    warning:  'bg-amber-100  text-amber-800  dark:bg-amber-900/40 dark:text-amber-300',
+    danger:   'bg-red-100    text-red-800    dark:bg-red-900/40   dark:text-red-300',
+    info:     'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300',
+    muted:    'bg-[var(--muted)] text-[var(--muted-foreground)]',
+};
+
+// Map application statuses to badge variants
+const STATUS_VARIANT: Record<Status, BadgeVariant> = {
+    APPLIED:      'default',
+    SCREENING:    'info',
+    INTERVIEWING: 'warning',
+    OFFER:        'success',
+    REJECTED:     'danger',
+    WITHDRAWN:    'muted',
+};
+
+const STATUS_LABEL: Record<Status, string> = {
+    APPLIED:      'Applied',
+    SCREENING:    'Screening',
+    INTERVIEWING: 'Interviewing',
+    OFFER:        'Offer',
+    REJECTED:     'Rejected',
+    WITHDRAWN:    'Withdrawn',
+};
+
+interface BadgeProps {
+    variant?: BadgeVariant;
+    children: React.ReactNode;
+    className?: string;
+}
+
+export default function Badge({ variant = 'default', children, className = '' }: BadgeProps) {
+    return (
+        <span
+            className={[
+                'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+                VARIANT_CLASSES[variant],
+                className,
+            ].join(' ')}
+        >
+            {children}
+        </span>
+    );
+}
+
+/** Convenience wrapper that maps a Status enum value to the correct Badge variant and label. */
+export function StatusBadge({ status, className }: { status: Status; className?: string }) {
+    return (
+        <Badge variant={STATUS_VARIANT[status]} className={className}>
+            {STATUS_LABEL[status]}
+        </Badge>
+    );
+}

--- a/frontend/components/ui/Card.tsx
+++ b/frontend/components/ui/Card.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+interface CardProps {
+    title: string;
+    value: string | number;
+    icon?: React.ReactNode;
+    subtitle?: string;
+    className?: string;
+}
+
+export default function Card({ title, value, icon, subtitle, className = '' }: CardProps) {
+    return (
+        <div
+            className={[
+                'rounded-xl border border-[var(--border)] bg-[var(--card)] p-5',
+                'flex items-start gap-4',
+                className,
+            ].join(' ')}
+        >
+            {icon && (
+                <div className="shrink-0 rounded-lg bg-[var(--muted)] p-2.5 text-[var(--muted-foreground)]">
+                    {icon}
+                </div>
+            )}
+            <div className="min-w-0">
+                <p className="text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
+                    {title}
+                </p>
+                <p className="mt-1 text-2xl font-bold text-[var(--card-foreground)] leading-none">
+                    {value}
+                </p>
+                {subtitle && (
+                    <p className="mt-1 text-xs text-[var(--muted-foreground)]">{subtitle}</p>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/components/ui/Pagination.tsx
+++ b/frontend/components/ui/Pagination.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+interface PaginationProps {
+    page: number;          // 0-based (matches Spring Pageable)
+    totalPages: number;
+    totalElements: number;
+    pageSize: number;
+    onPageChange: (page: number) => void;
+}
+
+function getPageNumbers(current: number, total: number): (number | '…')[] {
+    if (total <= 7) return Array.from({ length: total }, (_, i) => i);
+    if (current <= 3) return [0, 1, 2, 3, 4, '…', total - 1];
+    if (current >= total - 4) return [0, '…', total - 5, total - 4, total - 3, total - 2, total - 1];
+    return [0, '…', current - 1, current, current + 1, '…', total - 1];
+}
+
+export default function Pagination({
+    page,
+    totalPages,
+    totalElements,
+    pageSize,
+    onPageChange,
+}: PaginationProps) {
+    if (totalPages <= 1) return null;
+
+    const from = page * pageSize + 1;
+    const to = Math.min((page + 1) * pageSize, totalElements);
+    const pages = getPageNumbers(page, totalPages);
+
+    const btnBase =
+        'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors h-8 min-w-[2rem] px-2 disabled:opacity-40 disabled:cursor-not-allowed';
+    const btnDefault =
+        'border border-[var(--border)] bg-[var(--background)] text-[var(--foreground)] hover:bg-[var(--muted)]';
+    const btnActive =
+        'bg-[var(--primary)] text-[var(--primary-foreground)] border border-[var(--primary)]';
+
+    return (
+        <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-between">
+            <p className="text-sm text-[var(--muted-foreground)]">
+                Showing <span className="font-medium text-[var(--foreground)]">{from}–{to}</span> of{' '}
+                <span className="font-medium text-[var(--foreground)]">{totalElements}</span>
+            </p>
+
+            <div className="flex items-center gap-1">
+                <button
+                    onClick={() => onPageChange(page - 1)}
+                    disabled={page === 0}
+                    aria-label="Previous page"
+                    className={`${btnBase} ${btnDefault}`}
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="h-4 w-4">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+                    </svg>
+                </button>
+
+                {pages.map((p, i) =>
+                    p === '…' ? (
+                        <span key={`ellipsis-${i}`} className="px-1 text-[var(--muted-foreground)]">…</span>
+                    ) : (
+                        <button
+                            key={p}
+                            onClick={() => onPageChange(p)}
+                            aria-label={`Page ${p + 1}`}
+                            aria-current={p === page ? 'page' : undefined}
+                            className={`${btnBase} ${p === page ? btnActive : btnDefault}`}
+                        >
+                            {p + 1}
+                        </button>
+                    )
+                )}
+
+                <button
+                    onClick={() => onPageChange(page + 1)}
+                    disabled={page >= totalPages - 1}
+                    aria-label="Next page"
+                    className={`${btnBase} ${btnDefault}`}
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="h-4 w-4">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/frontend/components/ui/SearchInput.tsx
+++ b/frontend/components/ui/SearchInput.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface SearchInputProps {
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+    debounceMs?: number;
+    className?: string;
+}
+
+export default function SearchInput({
+    value,
+    onChange,
+    placeholder = 'Search…',
+    debounceMs = 300,
+    className = '',
+}: SearchInputProps) {
+    const [local, setLocal] = useState(value);
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // Keep local in sync if parent resets the value (e.g. on filter clear)
+    useEffect(() => { setLocal(value); }, [value]);
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const next = e.target.value;
+        setLocal(next);
+        if (timerRef.current) clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(() => onChange(next), debounceMs);
+    };
+
+    const handleClear = () => {
+        setLocal('');
+        if (timerRef.current) clearTimeout(timerRef.current);
+        onChange('');
+    };
+
+    return (
+        <div className={`relative ${className}`}>
+            {/* Search icon */}
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-[var(--muted-foreground)] pointer-events-none"
+            >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+            </svg>
+
+            <input
+                type="search"
+                value={local}
+                onChange={handleChange}
+                placeholder={placeholder}
+                className={[
+                    'w-full rounded-md border px-3 py-2 pl-9 text-sm outline-none transition-colors',
+                    'bg-[var(--background)] text-[var(--foreground)]',
+                    'border-[var(--border)] placeholder:text-[var(--muted-foreground)]',
+                    'focus:border-[var(--primary)] focus:ring-2 focus:ring-[var(--ring)]/30',
+                    local ? 'pr-8' : '',
+                ].join(' ')}
+            />
+
+            {/* Clear button */}
+            {local && (
+                <button
+                    type="button"
+                    onClick={handleClear}
+                    aria-label="Clear search"
+                    className="absolute right-2.5 top-1/2 -translate-y-1/2 text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="h-3.5 w-3.5">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
- Badge: generic variant badge (default/success/warning/danger/info/muted)
  + StatusBadge convenience wrapper mapping Status enum to correct variant/label
- Card: stats card with title, value, optional icon and subtitle
- Pagination: 0-based Spring-compatible, ellipsis windowing, prev/next arrows, "Showing X-Y of Z" label, hidden when totalPages <= 1
- SearchInput: debounced (300ms default) with search icon and clear button, syncs with parent value for external resets
- All components use CSS variables for full dark mode support