### PR TITLE
feat: add desktop sidebar with collapsible nav and user section

### DIFF
--- a/frontend/__tests__/login.test.tsx
+++ b/frontend/__tests__/login.test.tsx
@@ -16,6 +16,7 @@ jest.mock('@/lib/authService', () => ({
 
 jest.mock('@/lib/auth', () => ({
   setToken: jest.fn(),
+  setUsername: jest.fn(),
   getToken: jest.fn().mockReturnValue(null),
 }));
 

--- a/frontend/__tests__/register.test.tsx
+++ b/frontend/__tests__/register.test.tsx
@@ -16,6 +16,7 @@ jest.mock('@/lib/authService', () => ({
 
 jest.mock('@/lib/auth', () => ({
   setToken: jest.fn(),
+  setUsername: jest.fn(),
   getToken: jest.fn().mockReturnValue(null),
 }));
 

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { getApplications } from '@/lib/applicationService';
-import { isAuthenticated, removeToken } from '@/lib/auth';
+import { isAuthenticated, removeToken, removeUsername } from '@/lib/auth';
 import { Application } from '@/types';
 
 export default function DashboardPage() {
@@ -34,6 +34,7 @@ export default function DashboardPage() {
 
   const handleLogout = () => {
     removeToken();
+    removeUsername();
     router.push('/login');
   };
 

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { login } from '@/lib/authService';
-import { setToken } from '@/lib/auth';
+import { setToken, setUsername } from '@/lib/auth';
 import ThemeToggle from '@/components/ui/ThemeToggle';
 
 export default function LoginPage() {
@@ -22,6 +22,7 @@ export default function LoginPage() {
     try {
       const response = await login({ identifier, password });
       setToken(response.token);
+      setUsername(response.username);
       router.push('/dashboard');
     } catch {
       setError('Login failed. Please check your credentials.');

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { register } from '@/lib/authService';
-import { setToken } from '@/lib/auth';
+import { setToken, setUsername as persistUsername } from '@/lib/auth';
 import ThemeToggle from '@/components/ui/ThemeToggle';
 
 export default function RegisterPage() {
@@ -23,6 +23,7 @@ export default function RegisterPage() {
     try {
       const response = await register({ email, username, password });
       setToken(response.token);
+      persistUsername(response.username);
       router.push('/dashboard');
     } catch {
       setError('Registration failed. Email or username may already be taken.');

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -46,10 +46,10 @@ const IconChevronRight = () => (
 
 // --- Nav items config ---
 
-const NAV_ITEMS = [
-    { href: '/dashboard', label: 'Dashboard', icon: <IconDashboard /> },
-    { href: '/applications/new', label: 'New Application', icon: <IconPlus /> },
-    { href: '/settings', label: 'Settings', icon: <IconSettings /> },
+const NAV_ITEMS: { href: string; label: string; icon: React.ComponentType }[] = [
+    { href: '/dashboard', label: 'Dashboard', icon: IconDashboard },
+    { href: '/applications/new', label: 'New Application', icon: IconPlus },
+    { href: '/settings', label: 'Settings', icon: IconSettings },
 ];
 
 // --- Sidebar ---
@@ -103,12 +103,12 @@ export default function Sidebar() {
 
             {/* Nav items */}
             <nav className="flex-1 overflow-y-auto px-2 py-3 flex flex-col gap-1">
-                {NAV_ITEMS.map(item => (
+                {NAV_ITEMS.map(({ href, label, icon: Icon }) => (
                     <SidebarItem
-                        key={item.href}
-                        href={item.href}
-                        label={item.label}
-                        icon={item.icon}
+                        key={href}
+                        href={href}
+                        label={label}
+                        icon={<Icon />}
                         collapsed={collapsed}
                     />
                 ))}

--- a/frontend/components/layout/SidebarItem.tsx
+++ b/frontend/components/layout/SidebarItem.tsx
@@ -12,12 +12,13 @@ interface SidebarItemProps {
 
 export default function SidebarItem({ href, label, icon, collapsed }: SidebarItemProps) {
     const pathname = usePathname();
-    const isActive = pathname === href || (href !== '/' && pathname.startsWith(href));
+    const isActive = pathname === href || (href !== '/' && pathname.startsWith(href + '/'));
 
     return (
         <Link
             href={href}
             title={collapsed ? label : undefined}
+            aria-label={collapsed ? label : undefined}
             className={[
                 'flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors',
                 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]',

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -26,6 +26,7 @@ export const isAuthenticated = (): boolean => {
 
 //Saves username to localStorage after login/register
 export const setUsername = (username: string): void => {
+    if (typeof window === 'undefined') return;
     localStorage.setItem('username', username);
 };
 
@@ -37,5 +38,6 @@ export const getUsername = (): string | null => {
 
 //Clears username on logout
 export const removeUsername = (): void => {
+    if (typeof window === 'undefined') return;
     localStorage.removeItem('username');
 };


### PR DESCRIPTION
## Summary
- Adds `Sidebar.tsx` — persistent, collapsible (full ↔ icon-only) desktop sidebar with collapse state stored in `localStorage`
- Adds `SidebarItem.tsx` — nav item with icon, label, and active state highlighting
- Nav items: Dashboard, New Application, Settings; user section at bottom showing logged-in username
- Updates auth helpers in `lib/auth.ts` with `getUsername` helper
- Minor updates to existing pages and test mocks for compatibility

## Test plan
- [ ] Sidebar renders on dashboard with nav items visible
- [ ] Collapse toggle switches between full and icon-only modes
- [ ] Collapse state persists across page refresh (localStorage)
- [ ] Active nav item is highlighted based on current route
- [ ] User section at bottom shows logged-in username
- [ ] Frontend lint and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)