### PR TITLE
fix(layout): address all code review findings from Task 10b

### DIFF
--- a/frontend/__tests__/layout.appLayout.test.tsx
+++ b/frontend/__tests__/layout.appLayout.test.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable react/display-name */
+import { render, screen, fireEvent } from '@testing-library/react';
+import AppLayout from '@/app/(app)/layout';
+
+// Mock child components to isolate AppLayout logic
+jest.mock('@/components/layout/Sidebar', () => () => <aside data-testid="sidebar" />);
+jest.mock('@/components/layout/Header', () => ({ onMenuClick, title }: { onMenuClick: () => void; title: string }) => (
+    <div data-testid="header">
+        <button onClick={onMenuClick} aria-label="Open mobile menu">menu</button>
+        <span>{title}</span>
+    </div>
+));
+jest.mock('@/components/layout/MobileDrawer', () => ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => (
+    isOpen ? (
+        <div data-testid="mobile-drawer">
+            <button onClick={onClose} aria-label="Close menu">close</button>
+        </div>
+    ) : null
+));
+jest.mock('next/navigation', () => ({
+    usePathname: jest.fn(() => '/dashboard'),
+}));
+
+import { usePathname } from 'next/navigation';
+const mockUsePathname = usePathname as jest.Mock;
+
+describe('AppLayout', () => {
+    beforeEach(() => {
+        mockUsePathname.mockReturnValue('/dashboard');
+    });
+
+    it('renders the sidebar and header', () => {
+        render(<AppLayout><div>content</div></AppLayout>);
+        expect(screen.getByTestId('sidebar')).toBeInTheDocument();
+        expect(screen.getByTestId('header')).toBeInTheDocument();
+    });
+
+    it('renders children inside main', () => {
+        render(<AppLayout><p>page content</p></AppLayout>);
+        expect(screen.getByRole('main')).toContainElement(screen.getByText('page content'));
+    });
+
+    it('does not render MobileDrawer by default', () => {
+        render(<AppLayout><div /></AppLayout>);
+        expect(screen.queryByTestId('mobile-drawer')).not.toBeInTheDocument();
+    });
+
+    it('opens MobileDrawer when hamburger is clicked', () => {
+        render(<AppLayout><div /></AppLayout>);
+        fireEvent.click(screen.getByRole('button', { name: 'Open mobile menu' }));
+        expect(screen.getByTestId('mobile-drawer')).toBeInTheDocument();
+    });
+
+    it('closes MobileDrawer when onClose is called', () => {
+        render(<AppLayout><div /></AppLayout>);
+        fireEvent.click(screen.getByRole('button', { name: 'Open mobile menu' }));
+        expect(screen.getByTestId('mobile-drawer')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Close menu' }));
+        expect(screen.queryByTestId('mobile-drawer')).not.toBeInTheDocument();
+    });
+
+    it('passes "Dashboard" as title for /dashboard route', () => {
+        mockUsePathname.mockReturnValue('/dashboard');
+        render(<AppLayout><div /></AppLayout>);
+        expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    });
+
+    it('passes "New Application" as title for /applications/new route', () => {
+        mockUsePathname.mockReturnValue('/applications/new');
+        render(<AppLayout><div /></AppLayout>);
+        expect(screen.getByText('New Application')).toBeInTheDocument();
+    });
+
+    it('passes "Settings" as title for /settings route', () => {
+        mockUsePathname.mockReturnValue('/settings');
+        render(<AppLayout><div /></AppLayout>);
+        expect(screen.getByText('Settings')).toBeInTheDocument();
+    });
+
+    it('falls back to "Job Tracker" for unknown routes', () => {
+        mockUsePathname.mockReturnValue('/unknown-route');
+        render(<AppLayout><div /></AppLayout>);
+        expect(screen.getByText('Job Tracker')).toBeInTheDocument();
+    });
+});

--- a/frontend/__tests__/layout.header.test.tsx
+++ b/frontend/__tests__/layout.header.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import Header from '@/components/layout/Header';
+
+// Suppress Next.js navigation mock noise
+jest.mock('next/navigation', () => ({
+    usePathname: () => '/dashboard',
+}));
+
+describe('Header', () => {
+    it('renders the title', () => {
+        render(<Header onMenuClick={jest.fn()} title="Dashboard" />);
+        expect(screen.getByRole('heading', { level: 1, name: 'Dashboard' })).toBeInTheDocument();
+    });
+
+    it('renders the hamburger button with accessible label', () => {
+        render(<Header onMenuClick={jest.fn()} title="Dashboard" />);
+        expect(screen.getByRole('button', { name: 'Open mobile menu' })).toBeInTheDocument();
+    });
+
+    it('calls onMenuClick when the hamburger button is clicked', () => {
+        const onMenuClick = jest.fn();
+        render(<Header onMenuClick={onMenuClick} title="Dashboard" />);
+        fireEvent.click(screen.getByRole('button', { name: 'Open mobile menu' }));
+        expect(onMenuClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders the username from localStorage when present', () => {
+        localStorage.setItem('username', 'testuser');
+        render(<Header onMenuClick={jest.fn()} title="Dashboard" />);
+        expect(screen.getByText('testuser')).toBeInTheDocument();
+        localStorage.removeItem('username');
+    });
+
+    it('does not render a username section when localStorage has no username', () => {
+        localStorage.removeItem('username');
+        render(<Header onMenuClick={jest.fn()} title="Dashboard" />);
+        expect(screen.queryByText('testuser')).not.toBeInTheDocument();
+    });
+});

--- a/frontend/__tests__/layout.mobileDrawer.test.tsx
+++ b/frontend/__tests__/layout.mobileDrawer.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import MobileDrawer from '@/components/layout/MobileDrawer';
+
+jest.mock('next/navigation', () => ({
+    usePathname: () => '/dashboard',
+}));
+
+describe('MobileDrawer', () => {
+    it('renders nothing when isOpen is false', () => {
+        render(<MobileDrawer isOpen={false} onClose={jest.fn()} />);
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('renders the drawer with correct ARIA attributes when open', () => {
+        render(<MobileDrawer isOpen={true} onClose={jest.fn()} />);
+        const dialog = screen.getByRole('dialog');
+        expect(dialog).toBeInTheDocument();
+        expect(dialog).toHaveAttribute('aria-modal', 'true');
+        expect(dialog).toHaveAttribute('aria-label', 'Navigation menu');
+    });
+
+    it('renders all nav items when open', () => {
+        render(<MobileDrawer isOpen={true} onClose={jest.fn()} />);
+        expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /new application/i })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /settings/i })).toBeInTheDocument();
+    });
+
+    it('calls onClose when the backdrop is clicked', () => {
+        const onClose = jest.fn();
+        render(<MobileDrawer isOpen={true} onClose={onClose} />);
+        const backdrop = document.querySelector('[aria-hidden="true"]') as HTMLElement;
+        fireEvent.click(backdrop);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when the close (X) button is clicked', () => {
+        const onClose = jest.fn();
+        render(<MobileDrawer isOpen={true} onClose={onClose} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Close menu' }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when Escape key is pressed', () => {
+        const onClose = jest.fn();
+        render(<MobileDrawer isOpen={true} onClose={onClose} />);
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onClose on Escape when closed', () => {
+        const onClose = jest.fn();
+        render(<MobileDrawer isOpen={false} onClose={onClose} />);
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('sets body overflow to hidden when open', () => {
+        render(<MobileDrawer isOpen={true} onClose={jest.fn()} />);
+        expect(document.body.style.overflow).toBe('hidden');
+    });
+
+    it('restores body overflow when unmounted', () => {
+        const { unmount } = render(<MobileDrawer isOpen={true} onClose={jest.fn()} />);
+        unmount();
+        expect(document.body.style.overflow).toBe('');
+    });
+
+    it('focuses the close button on open', () => {
+        render(<MobileDrawer isOpen={true} onClose={jest.fn()} />);
+        expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Close menu' }));
+    });
+
+    it('calls onClose when a nav link is clicked', () => {
+        const onClose = jest.fn();
+        render(<MobileDrawer isOpen={true} onClose={onClose} />);
+        fireEvent.click(screen.getByRole('link', { name: /dashboard/i }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders the username from localStorage when present', () => {
+        localStorage.setItem('username', 'drawertestuser');
+        render(<MobileDrawer isOpen={true} onClose={jest.fn()} />);
+        expect(screen.getByText('drawertestuser')).toBeInTheDocument();
+        localStorage.removeItem('username');
+    });
+});

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -1,12 +1,32 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
 import Sidebar from '@/components/layout/Sidebar';
 import Header from '@/components/layout/Header';
 import MobileDrawer from '@/components/layout/MobileDrawer';
 
+const ROUTE_TITLES: Record<string, string> = {
+    '/dashboard': 'Dashboard',
+    '/applications/new': 'New Application',
+    '/settings': 'Settings',
+};
+
 export default function AppLayout({ children }: { children: React.ReactNode }) {
     const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+    const menuTriggerRef = useRef<Element | null>(null);
+    const pathname = usePathname();
+    const title = ROUTE_TITLES[pathname] ?? 'Job Tracker';
+
+    const openMenu = useCallback(() => {
+        menuTriggerRef.current = document.activeElement;
+        setIsMobileMenuOpen(true);
+    }, []);
+
+    const closeMenu = useCallback(() => {
+        setIsMobileMenuOpen(false);
+        (menuTriggerRef.current as HTMLElement)?.focus();
+    }, []);
 
     return (
         <div className="flex h-screen overflow-hidden bg-background">
@@ -16,15 +36,15 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
             {/* Mobile Drawer */}
             <MobileDrawer
                 isOpen={isMobileMenuOpen}
-                onClose={() => setIsMobileMenuOpen(false)}
+                onClose={closeMenu}
             />
 
             {/* Main Content Area */}
             <div className="flex flex-1 flex-col overflow-hidden">
                 {/* Mobile Header */}
                 <Header
-                    onMenuClick={() => setIsMobileMenuOpen(true)}
-                    title="Job Tracker"
+                    onMenuClick={openMenu}
+                    title={title}
                 />
 
                 {/* Page Content */}

--- a/frontend/components/layout/Header.tsx
+++ b/frontend/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo } from 'react';
 import { getUsername } from '@/lib/auth';
 
 interface HeaderProps {
@@ -15,25 +15,25 @@ const IconMenu = () => (
 );
 
 export default function Header({ onMenuClick, title }: HeaderProps) {
-    const [username] = useState<string | null>(() => {
+    const username = useMemo<string | null>(() => {
         if (typeof window === 'undefined') return null;
         return getUsername();
-    });
+    }, []);
 
     return (
-        <header className="flex h-14 shrink-0 items-center justify-between border-b border-border bg-card px-4 md:hidden">
+        <header className="flex h-14 shrink-0 items-center justify-between border-b border-[var(--border)] bg-[var(--card)] px-4 md:hidden">
             <div className="flex items-center gap-3">
                 <button
                     onClick={onMenuClick}
-                    className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+                    className="rounded-md p-1.5 text-[var(--muted-foreground)] hover:bg-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
                     aria-label="Open mobile menu"
                 >
                     <IconMenu />
                 </button>
-                <h1 className="text-lg font-semibold text-foreground">{title}</h1>
+                <h1 className="text-lg font-semibold text-[var(--foreground)]">{title}</h1>
             </div>
             {username && (
-                <div className="text-sm font-medium text-muted-foreground truncate max-w-[120px]">
+                <div className="text-sm font-medium text-[var(--muted-foreground)] truncate max-w-[120px]">
                     {username}
                 </div>
             )}

--- a/frontend/components/layout/MobileDrawer.tsx
+++ b/frontend/components/layout/MobileDrawer.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { getUsername } from '@/lib/auth';
 import SidebarItem from './SidebarItem';
+import { NAV_ITEMS, IconUser } from './navItems';
 
 interface MobileDrawerProps {
     isOpen: boolean;
@@ -15,68 +16,93 @@ const IconClose = () => (
     </svg>
 );
 
-const IconDashboard = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-        <path fillRule="evenodd" d="M4.25 2A2.25 2.25 0 002 4.25v2.5A2.25 2.25 0 004.25 9h2.5A2.25 2.25 0 009 6.75v-2.5A2.25 2.25 0 006.75 2h-2.5zm0 9A2.25 2.25 0 002 13.25v2.5A2.25 2.25 0 004.25 18h2.5A2.25 2.25 0 009 15.75v-2.5A2.25 2.25 0 006.75 11h-2.5zm6.5-9A2.25 2.25 0 008.5 4.25v2.5A2.25 2.25 0 0010.75 9h2.5A2.25 2.25 0 0015.5 6.75v-2.5A2.25 2.25 0 0013.25 2h-2.5zm0 9a2.25 2.25 0 00-2.25 2.25v2.5a2.25 2.25 0 002.25 2.25h2.5a2.25 2.25 0 002.25-2.25v-2.5a2.25 2.25 0 00-2.25-2.25h-2.5z" clipRule="evenodd" />
-    </svg>
-);
-
-const IconPlus = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-        <path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z" />
-    </svg>
-);
-
-const IconSettings = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-        <path fillRule="evenodd" d="M7.84 1.804A1 1 0 018.82 1h2.36a1 1 0 01.98.804l.295 1.473c.497.144.971.342 1.416.587l1.25-.834a1 1 0 011.262.125l1.668 1.668a1 1 0 01.125 1.262l-.834 1.25c.245.445.443.919.587 1.416l1.473.294a1 1 0 01.804.98v2.361a1 1 0 01-.804.98l-1.473.295a6.95 6.95 0 01-.587 1.416l.834 1.25a1 1 0 01-.125 1.262l-1.668 1.668a1 1 0 01-1.262.125l-1.25-.834a6.953 6.953 0 01-1.416.587l-.294 1.473a1 1 0 01-.98.804H8.82a1 1 0 01-.98-.804l-.295-1.473a6.957 6.957 0 01-1.416-.587l-1.25.834a1 1 0 01-1.262-.125L1.95 15.349a1 1 0 01-.125-1.262l.834-1.25a6.957 6.957 0 01-.587-1.416l-1.473-.294A1 1 0 010 11.18V8.82a1 1 0 01.804-.98l1.473-.295c.144-.497.342-.971.587-1.416l-.834-1.25a1 1 0 01.125-1.262L3.823 1.95a1 1 0 011.262-.125l1.25.834a6.957 6.957 0 011.416-.587L7.84 1.804zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd" />
-    </svg>
-);
-
-const IconUser = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-        <path d="M10 8a3 3 0 100-6 3 3 0 000 6zM3.465 14.493a1.23 1.23 0 00.41 1.412A9.957 9.957 0 0010 18c2.31 0 4.438-.784 6.131-2.1.43-.333.604-.903.408-1.41a7.002 7.002 0 00-13.074.003z" />
-    </svg>
-);
-
-const NAV_ITEMS = [
-    { href: '/dashboard', label: 'Dashboard', icon: IconDashboard },
-    { href: '/applications/new', label: 'New Application', icon: IconPlus },
-    { href: '/settings', label: 'Settings', icon: IconSettings },
-];
+const FOCUSABLE_SELECTORS = 'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
-    const [username] = useState<string | null>(() => {
+    const username = useMemo<string | null>(() => {
         if (typeof window === 'undefined') return null;
         return getUsername();
-    });
+    }, []);
 
+    const drawerRef = useRef<HTMLDivElement>(null);
+    const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+    // Body scroll lock — only set overflow:hidden when open; cleanup always restores it.
+    // The else branch is intentionally absent: the component unmounts when isOpen is false,
+    // so only the cleanup fires on close, which is sufficient.
     useEffect(() => {
         if (isOpen) {
             document.body.style.overflow = 'hidden';
-        } else {
-            document.body.style.overflow = '';
         }
         return () => { document.body.style.overflow = ''; };
     }, [isOpen]);
+
+    // Focus management: move focus into the drawer on open, trap Tab, close on Escape.
+    useEffect(() => {
+        if (!isOpen) return;
+
+        closeButtonRef.current?.focus();
+
+        const drawerEl = drawerRef.current;
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                onClose();
+                return;
+            }
+            if (e.key === 'Tab' && drawerEl) {
+                const focusable = Array.from(
+                    drawerEl.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)
+                );
+                if (focusable.length === 0) return;
+                const first = focusable[0];
+                const last = focusable[focusable.length - 1];
+                if (e.shiftKey) {
+                    if (document.activeElement === first) {
+                        e.preventDefault();
+                        last.focus();
+                    }
+                } else {
+                    if (document.activeElement === last) {
+                        e.preventDefault();
+                        first.focus();
+                    }
+                }
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [isOpen, onClose]);
 
     if (!isOpen) return null;
 
     return (
         <div className="fixed inset-0 z-50 md:hidden flex">
             {/* Backdrop */}
-            <div className="fixed inset-0 bg-black/50 transition-opacity" aria-hidden="true" onClick={onClose} />
+            <div
+                className="fixed inset-0 bg-black/50 transition-opacity"
+                aria-hidden="true"
+                onClick={onClose}
+            />
 
-            {/* Drawer */}
-            <div className="relative flex w-64 flex-col bg-card shadow-xl h-full border-r border-border">
-                <div className="flex items-center justify-between h-14 px-4 border-b border-border shrink-0">
-                    <span className="font-semibold text-sm text-foreground truncate">
+            {/* Drawer panel */}
+            <div
+                ref={drawerRef}
+                role="dialog"
+                aria-modal="true"
+                aria-label="Navigation menu"
+                className="relative flex w-64 flex-col bg-[var(--card)] shadow-xl h-full border-r border-[var(--border)]"
+            >
+                <div className="flex items-center justify-between h-14 px-4 border-b border-[var(--border)] shrink-0">
+                    <span className="font-semibold text-sm text-[var(--foreground)] truncate">
                         Job Tracker
                     </span>
                     <button
+                        ref={closeButtonRef}
                         onClick={onClose}
                         aria-label="Close menu"
-                        className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+                        className="rounded-md p-1.5 text-[var(--muted-foreground)] hover:bg-[var(--muted)] hover:text-[var(--foreground)] transition-colors"
                     >
                         <IconClose />
                     </button>
@@ -84,18 +110,23 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
 
                 <nav className="flex-1 overflow-y-auto px-2 py-3 flex flex-col gap-1">
                     {NAV_ITEMS.map(({ href, label, icon: Icon }) => (
-                        <div key={href} onClick={onClose}>
-                            <SidebarItem href={href} label={label} icon={<Icon />} collapsed={false} />
-                        </div>
+                        <SidebarItem
+                            key={href}
+                            href={href}
+                            label={label}
+                            icon={<Icon />}
+                            collapsed={false}
+                            onClick={onClose}
+                        />
                     ))}
                 </nav>
 
-                <div className="shrink-0 border-t border-border px-4 py-4 flex items-center gap-3">
-                    <span className="shrink-0 h-5 w-5 text-muted-foreground" aria-hidden="true">
+                <div className="shrink-0 border-t border-[var(--border)] px-4 py-4 flex items-center gap-3">
+                    <span className="shrink-0 h-5 w-5 text-[var(--muted-foreground)]" aria-hidden="true">
                         <IconUser />
                     </span>
                     {username && (
-                        <span className="text-sm font-medium text-muted-foreground truncate">{username}</span>
+                        <span className="text-sm font-medium text-[var(--muted-foreground)] truncate">{username}</span>
                     )}
                 </div>
             </div>

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -3,34 +3,11 @@
 import { useCallback, useState } from 'react';
 import { getUsername } from '@/lib/auth';
 import SidebarItem from './SidebarItem';
+import { NAV_ITEMS, IconUser } from './navItems';
 
 const STORAGE_KEY = 'sidebar-collapsed';
 
-// --- Icons (inline heroicons, 20×20 solid style) ---
-
-const IconDashboard = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-        <path fillRule="evenodd" d="M4.25 2A2.25 2.25 0 002 4.25v2.5A2.25 2.25 0 004.25 9h2.5A2.25 2.25 0 009 6.75v-2.5A2.25 2.25 0 006.75 2h-2.5zm0 9A2.25 2.25 0 002 13.25v2.5A2.25 2.25 0 004.25 18h2.5A2.25 2.25 0 009 15.75v-2.5A2.25 2.25 0 006.75 11h-2.5zm6.5-9A2.25 2.25 0 008.5 4.25v2.5A2.25 2.25 0 0010.75 9h2.5A2.25 2.25 0 0015.5 6.75v-2.5A2.25 2.25 0 0013.25 2h-2.5zm0 9a2.25 2.25 0 00-2.25 2.25v2.5a2.25 2.25 0 002.25 2.25h2.5a2.25 2.25 0 002.25-2.25v-2.5a2.25 2.25 0 00-2.25-2.25h-2.5z" clipRule="evenodd" />
-    </svg>
-);
-
-const IconPlus = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-        <path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z" />
-    </svg>
-);
-
-const IconSettings = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-        <path fillRule="evenodd" d="M7.84 1.804A1 1 0 018.82 1h2.36a1 1 0 01.98.804l.295 1.473c.497.144.971.342 1.416.587l1.25-.834a1 1 0 011.262.125l1.668 1.668a1 1 0 01.125 1.262l-.834 1.25c.245.445.443.919.587 1.416l1.473.294a1 1 0 01.804.98v2.361a1 1 0 01-.804.98l-1.473.295a6.95 6.95 0 01-.587 1.416l.834 1.25a1 1 0 01-.125 1.262l-1.668 1.668a1 1 0 01-1.262.125l-1.25-.834a6.953 6.953 0 01-1.416.587l-.294 1.473a1 1 0 01-.98.804H8.82a1 1 0 01-.98-.804l-.295-1.473a6.957 6.957 0 01-1.416-.587l-1.25.834a1 1 0 01-1.262-.125L1.95 15.349a1 1 0 01-.125-1.262l.834-1.25a6.957 6.957 0 01-.587-1.416l-1.473-.294A1 1 0 010 11.18V8.82a1 1 0 01.804-.98l1.473-.295c.144-.497.342-.971.587-1.416l-.834-1.25a1 1 0 01.125-1.262L3.823 1.95a1 1 0 011.262-.125l1.25.834a6.957 6.957 0 011.416-.587L7.84 1.804zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd" />
-    </svg>
-);
-
-const IconUser = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-        <path d="M10 8a3 3 0 100-6 3 3 0 000 6zM3.465 14.493a1.23 1.23 0 00.41 1.412A9.957 9.957 0 0010 18c2.31 0 4.438-.784 6.131-2.1.43-.333.604-.903.408-1.41a7.002 7.002 0 00-13.074.003z" />
-    </svg>
-);
+// --- Icons (Sidebar-only: collapse toggles) ---
 
 const IconChevronLeft = () => (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -43,14 +20,6 @@ const IconChevronRight = () => (
         <path fillRule="evenodd" d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z" clipRule="evenodd" />
     </svg>
 );
-
-// --- Nav items config ---
-
-const NAV_ITEMS: { href: string; label: string; icon: React.ComponentType }[] = [
-    { href: '/dashboard', label: 'Dashboard', icon: IconDashboard },
-    { href: '/applications/new', label: 'New Application', icon: IconPlus },
-    { href: '/settings', label: 'Settings', icon: IconSettings },
-];
 
 // --- Sidebar ---
 

--- a/frontend/components/layout/SidebarItem.tsx
+++ b/frontend/components/layout/SidebarItem.tsx
@@ -8,15 +8,17 @@ interface SidebarItemProps {
     label: string;
     icon: React.ReactNode;
     collapsed: boolean;
+    onClick?: () => void;
 }
 
-export default function SidebarItem({ href, label, icon, collapsed }: SidebarItemProps) {
+export default function SidebarItem({ href, label, icon, collapsed, onClick }: SidebarItemProps) {
     const pathname = usePathname();
     const isActive = pathname === href || (href !== '/' && pathname.startsWith(href + '/'));
 
     return (
         <Link
             href={href}
+            onClick={onClick}
             title={collapsed ? label : undefined}
             aria-label={collapsed ? label : undefined}
             className={[

--- a/frontend/components/layout/navItems.tsx
+++ b/frontend/components/layout/navItems.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+export const IconDashboard = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fillRule="evenodd" d="M4.25 2A2.25 2.25 0 002 4.25v2.5A2.25 2.25 0 004.25 9h2.5A2.25 2.25 0 009 6.75v-2.5A2.25 2.25 0 006.75 2h-2.5zm0 9A2.25 2.25 0 002 13.25v2.5A2.25 2.25 0 004.25 18h2.5A2.25 2.25 0 009 15.75v-2.5A2.25 2.25 0 006.75 11h-2.5zm6.5-9A2.25 2.25 0 008.5 4.25v2.5A2.25 2.25 0 0010.75 9h2.5A2.25 2.25 0 0015.5 6.75v-2.5A2.25 2.25 0 0013.25 2h-2.5zm0 9a2.25 2.25 0 00-2.25 2.25v2.5a2.25 2.25 0 002.25 2.25h2.5a2.25 2.25 0 002.25-2.25v-2.5a2.25 2.25 0 00-2.25-2.25h-2.5z" clipRule="evenodd" />
+    </svg>
+);
+
+export const IconPlus = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z" />
+    </svg>
+);
+
+export const IconSettings = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fillRule="evenodd" d="M7.84 1.804A1 1 0 018.82 1h2.36a1 1 0 01.98.804l.295 1.473c.497.144.971.342 1.416.587l1.25-.834a1 1 0 011.262.125l1.668 1.668a1 1 0 01.125 1.262l-.834 1.25c.245.445.443.919.587 1.416l1.473.294a1 1 0 01.804.98v2.361a1 1 0 01-.804.98l-1.473.295a6.95 6.95 0 01-.587 1.416l.834 1.25a1 1 0 01-.125 1.262l-1.668 1.668a1 1 0 01-1.262.125l-1.25-.834a6.953 6.953 0 01-1.416.587l-.294 1.473a1 1 0 01-.98.804H8.82a1 1 0 01-.98-.804l-.295-1.473a6.957 6.957 0 01-1.416-.587l-1.25.834a1 1 0 01-1.262-.125L1.95 15.349a1 1 0 01-.125-1.262l.834-1.25a6.957 6.957 0 01-.587-1.416l-1.473-.294A1 1 0 010 11.18V8.82a1 1 0 01.804-.98l1.473-.295c.144-.497.342-.971.587-1.416l-.834-1.25a1 1 0 01.125-1.262L3.823 1.95a1 1 0 011.262-.125l1.25.834a6.957 6.957 0 011.416-.587L7.84 1.804zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd" />
+    </svg>
+);
+
+export const IconUser = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path d="M10 8a3 3 0 100-6 3 3 0 000 6zM3.465 14.493a1.23 1.23 0 00.41 1.412A9.957 9.957 0 0010 18c2.31 0 4.438-.784 6.131-2.1.43-.333.604-.903.408-1.41a7.002 7.002 0 00-13.074.003z" />
+    </svg>
+);
+
+export const NAV_ITEMS: { href: string; label: string; icon: React.ComponentType }[] = [
+    { href: '/dashboard', label: 'Dashboard', icon: IconDashboard },
+    { href: '/applications/new', label: 'New Application', icon: IconPlus },
+    { href: '/settings', label: 'Settings', icon: IconSettings },
+];


### PR DESCRIPTION
Accessibility (must-fix):
- MobileDrawer: remove dead else branch from scroll-lock effect
- MobileDrawer: add Escape key listener and focus trap (Tab/Shift+Tab)
- MobileDrawer: move focus to close button on open; return focus to trigger on close (captured in AppLayout via menuTriggerRef)
- MobileDrawer: add role="dialog", aria-modal="true", aria-label
- SidebarItem: add optional onClick prop forwarded to <Link> to replace the non-interactive <div onClick> wrapper in MobileDrawer

Refactor (should-fix):
- Extract shared icons and NAV_ITEMS to navItems.tsx, eliminating duplication between Sidebar and MobileDrawer
- AppLayout: derive page title from usePathname (ROUTE_TITLES map) instead of hardcoding "Job Tracker" for every route
- AppLayout: useCallback for openMenu/closeMenu passed as props
- Header + MobileDrawer: align Tailwind syntax to var(--...) form, consistent with Sidebar

Nit:
- Header + MobileDrawer: replace useState (no setter) with useMemo

Tests:
- Add layout.header.test.tsx (5 tests)
- Add layout.mobileDrawer.test.tsx (12 tests)
- Add layout.appLayout.test.tsx (9 tests)
- All 125 tests pass, lint clean