### PR TITLE
feat(frontend): add Axios response interceptors for session expiry (T…

### DIFF
--- a/frontend/__tests__/layout.apiInterceptorSetup.test.tsx
+++ b/frontend/__tests__/layout.apiInterceptorSetup.test.tsx
@@ -1,0 +1,57 @@
+import { render } from '@testing-library/react';
+import ApiInterceptorSetup from '@/components/layout/ApiInterceptorSetup';
+import { injectToast } from '@/lib/api';
+import { useToast } from '@/context/ToastContext';
+
+jest.mock('@/lib/api', () => ({
+    injectToast: jest.fn(),
+    default: { interceptors: { request: { use: jest.fn() }, response: { use: jest.fn() } } },
+}));
+
+jest.mock('@/context/ToastContext', () => ({
+    useToast: jest.fn(),
+}));
+
+const mockToast = {
+    error: jest.fn(),
+    warning: jest.fn(),
+    success: jest.fn(),
+    info: jest.fn(),
+};
+
+describe('ApiInterceptorSetup', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (useToast as jest.Mock).mockReturnValue({ toast: mockToast });
+    });
+
+    it('calls injectToast with a function on mount', () => {
+        render(<ApiInterceptorSetup />);
+        expect(injectToast).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('renders nothing', () => {
+        const { container } = render(<ApiInterceptorSetup />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('clears the injected toast on unmount', () => {
+        const { unmount } = render(<ApiInterceptorSetup />);
+        unmount();
+        expect(injectToast).toHaveBeenLastCalledWith(null);
+    });
+
+    it('injected function calls toast.error for error type', () => {
+        render(<ApiInterceptorSetup />);
+        const injected = (injectToast as jest.Mock).mock.calls[0][0] as (type: string, msg: string) => void;
+        injected('error', 'Something went wrong');
+        expect(mockToast.error).toHaveBeenCalledWith('Something went wrong');
+    });
+
+    it('injected function calls toast.warning for warning type', () => {
+        render(<ApiInterceptorSetup />);
+        const injected = (injectToast as jest.Mock).mock.calls[0][0] as (type: string, msg: string) => void;
+        injected('warning', 'Watch out');
+        expect(mockToast.warning).toHaveBeenCalledWith('Watch out');
+    });
+});

--- a/frontend/app/Providers.tsx
+++ b/frontend/app/Providers.tsx
@@ -2,11 +2,15 @@
 
 import { ThemeProvider } from '@/context/ThemeContext';
 import { ToastProvider } from '@/context/ToastContext';
+import ApiInterceptorSetup from '@/components/layout/ApiInterceptorSetup';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
     return (
         <ThemeProvider>
-            <ToastProvider>{children}</ToastProvider>
+            <ToastProvider>
+                <ApiInterceptorSetup />
+                {children}
+            </ToastProvider>
         </ThemeProvider>
     );
 }

--- a/frontend/components/layout/ApiInterceptorSetup.tsx
+++ b/frontend/components/layout/ApiInterceptorSetup.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useToast } from '@/context/ToastContext';
+import { injectToast } from '@/lib/api';
+
+/**
+ * Null-rendering component that wires the ToastContext into the Axios
+ * response interceptor. Must be rendered inside ToastProvider.
+ */
+export default function ApiInterceptorSetup() {
+    const { toast } = useToast();
+
+    useEffect(() => {
+        injectToast((type, message) => {
+            if (type === 'error') toast.error(message);
+            else toast.warning(message);
+        });
+        return () => { injectToast(null); };
+    }, [toast]);
+
+    return null;
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { removeToken, removeUsername } from './auth';
 
 const api = axios.create({
     baseURL: process.env.NEXT_PUBLIC_API_URL,
@@ -7,7 +8,7 @@ const api = axios.create({
     },
 });
 
-//Add Auth token to requests
+// Request interceptor — injects Bearer token on every request
 api.interceptors.request.use((config) => {
     const token = localStorage.getItem('token');
     if (token) {
@@ -15,5 +16,40 @@ api.interceptors.request.use((config) => {
     }
     return config;
 });
+
+// Injected toast callback — set at app boot by ApiInterceptorSetup
+type ToastFn = (type: 'error' | 'warning', message: string) => void;
+let _toast: ToastFn | null = null;
+
+export function injectToast(fn: ToastFn | null) {
+    _toast = fn;
+}
+
+// Response interceptor — handles auth expiry and common HTTP errors
+api.interceptors.response.use(
+    (response) => response,
+    (error) => {
+        const status = error.response?.status;
+
+        if (status === 401) {
+            // Only treat as session expiry if there was a token; otherwise it's a
+            // failed login attempt (wrong credentials) and should be handled by the caller.
+            const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+            if (token) {
+                removeToken();
+                removeUsername();
+                window.location.href = '/login?expired=true';
+            }
+        } else if (status === 403) {
+            _toast?.('error', "You don't have permission");
+        } else if (status === 500) {
+            _toast?.('error', 'Server error — please try again');
+        } else if (!error.response) {
+            _toast?.('error', 'Connection failed');
+        }
+
+        return Promise.reject(error);
+    },
+);
 
 export default api;


### PR DESCRIPTION
…ask 13)

- lib/api.ts: add response interceptor handling 401 (session expiry redirect), 403 (permission toast), 500 (server error toast), network error (connection toast)
- 401 redirect only fires when a token exists — prevents false redirect on wrong login credentials
- Export injectToast() to wire React toast context into the plain-module interceptor
- ApiInterceptorSetup.tsx: null-rendering client component that calls injectToast on mount and clears it on unmount; rendered inside ToastProvider in Providers.tsx
- Add 5 tests covering mount wiring, unmount cleanup, and toast dispatch by type