### PR TITLE
feat(frontend): add offline detection banner (Task 14)

### DIFF
--- a/frontend/__tests__/layout.offlineBanner.test.tsx
+++ b/frontend/__tests__/layout.offlineBanner.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import OfflineBanner from '@/components/layout/OfflineBanner';
+
+function setOnlineStatus(online: boolean) {
+    Object.defineProperty(navigator, 'onLine', {
+        get: () => online,
+        configurable: true,
+    });
+}
+
+describe('OfflineBanner', () => {
+    beforeEach(() => {
+        setOnlineStatus(true);
+    });
+
+    afterEach(() => {
+        setOnlineStatus(true);
+    });
+
+    it('renders nothing when online', () => {
+        setOnlineStatus(true);
+        const { container } = render(<OfflineBanner />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('shows the banner when offline', () => {
+        setOnlineStatus(false);
+        render(<OfflineBanner />);
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByText(/offline/i)).toBeInTheDocument();
+        expect(screen.getByText(/changes will not be saved/i)).toBeInTheDocument();
+    });
+
+    it('shows a Retry button when offline', () => {
+        setOnlineStatus(false);
+        render(<OfflineBanner />);
+        expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    });
+
+    it('hides the banner when connection is restored', () => {
+        setOnlineStatus(false);
+        render(<OfflineBanner />);
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+
+        act(() => {
+            setOnlineStatus(true);
+            window.dispatchEvent(new Event('online'));
+        });
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('shows the banner when going offline', () => {
+        setOnlineStatus(true);
+        render(<OfflineBanner />);
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+        act(() => {
+            setOnlineStatus(false);
+            window.dispatchEvent(new Event('offline'));
+        });
+
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    it('Retry button invokes the onRetry callback', () => {
+        setOnlineStatus(false);
+        const onRetry = jest.fn();
+        render(<OfflineBanner onRetry={onRetry} />);
+        fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+        expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/app/Providers.tsx
+++ b/frontend/app/Providers.tsx
@@ -3,12 +3,14 @@
 import { ThemeProvider } from '@/context/ThemeContext';
 import { ToastProvider } from '@/context/ToastContext';
 import ApiInterceptorSetup from '@/components/layout/ApiInterceptorSetup';
+import OfflineBanner from '@/components/layout/OfflineBanner';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
     return (
         <ThemeProvider>
             <ToastProvider>
                 <ApiInterceptorSetup />
+                <OfflineBanner />
                 {children}
             </ToastProvider>
         </ThemeProvider>

--- a/frontend/components/layout/OfflineBanner.tsx
+++ b/frontend/components/layout/OfflineBanner.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+function subscribe(callback: () => void) {
+    window.addEventListener('online', callback);
+    window.addEventListener('offline', callback);
+    return () => {
+        window.removeEventListener('online', callback);
+        window.removeEventListener('offline', callback);
+    };
+}
+
+function getSnapshot() {
+    return !navigator.onLine;
+}
+
+function getServerSnapshot() {
+    return false; // assume online during SSR
+}
+
+interface OfflineBannerProps {
+    onRetry?: () => void;
+}
+
+export default function OfflineBanner({ onRetry = () => window.location.reload() }: OfflineBannerProps) {
+    const isOffline = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+    if (!isOffline) return null;
+
+    return (
+        <div
+            role="alert"
+            className="fixed left-0 right-0 top-0 z-50 flex items-center justify-between gap-3 bg-amber-500 px-4 py-2 text-sm font-medium text-white"
+        >
+            <span>You appear to be offline. Changes will not be saved.</span>
+            <button
+                onClick={onRetry}
+                className="rounded border border-white/50 px-3 py-1 text-xs transition-colors hover:bg-white/20"
+            >
+                Retry
+            </button>
+        </div>
+    );
+}


### PR DESCRIPTION
- OfflineBanner.tsx: uses useSyncExternalStore with online/offline window events to reactively show/hide a fixed top banner when network is unavailable; server snapshot returns false (assume online during SSR)
- onRetry prop (default: window.location.reload) keeps the real behaviour intact while making the component testable without JSDOM location hacks
- Renders in Providers.tsx so it appears globally across all routes
- 6 tests: online/offline state, event-driven transitions, retry callback