### PR TITLE
feat(frontend): add error message mapping (Task 15)

### DIFF
--- a/frontend/__tests__/lib.errorMessages.test.ts
+++ b/frontend/__tests__/lib.errorMessages.test.ts
@@ -1,0 +1,61 @@
+import { getErrorMessage, FALLBACK_ERROR } from '@/lib/errorMessages';
+
+function axiosError(message: string) {
+    return { response: { data: { message } } };
+}
+
+describe('getErrorMessage', () => {
+    it('maps "Invalid credentials" to a friendly login message', () => {
+        expect(getErrorMessage(axiosError('Invalid credentials'))).toBe(
+            'Invalid email/username or password.'
+        );
+    });
+
+    it('is case-insensitive for pattern matching', () => {
+        expect(getErrorMessage(axiosError('INVALID CREDENTIALS'))).toBe(
+            'Invalid email/username or password.'
+        );
+    });
+
+    it('maps "Email or username already taken" to a friendly registration message', () => {
+        expect(getErrorMessage(axiosError('Email or username already taken'))).toBe(
+            'This email or username is already registered.'
+        );
+    });
+
+    it('maps "Application not found" to a friendly application message', () => {
+        expect(getErrorMessage(axiosError('Application not found'))).toBe(
+            'This application no longer exists.'
+        );
+    });
+
+    it('maps "Access denied" to a friendly permission message', () => {
+        expect(getErrorMessage(axiosError('Access denied'))).toBe(
+            "You don't have permission to do this."
+        );
+    });
+
+    it('returns fallback for an unknown backend message', () => {
+        expect(getErrorMessage(axiosError('Unexpected internal error'))).toBe(FALLBACK_ERROR);
+    });
+
+    it('returns fallback for a plain Error with no response', () => {
+        expect(getErrorMessage(new Error('Network error'))).toBe(FALLBACK_ERROR);
+    });
+
+    it('returns fallback for null', () => {
+        expect(getErrorMessage(null)).toBe(FALLBACK_ERROR);
+    });
+
+    it('returns fallback for undefined', () => {
+        expect(getErrorMessage(undefined)).toBe(FALLBACK_ERROR);
+    });
+
+    it('returns fallback when response has no data', () => {
+        expect(getErrorMessage({ response: {} })).toBe(FALLBACK_ERROR);
+    });
+
+    it('returns fallback when response data message is not a string', () => {
+        expect(getErrorMessage({ response: { data: { message: 42 } } })).toBe(FALLBACK_ERROR);
+    });
+});

--- a/frontend/__tests__/login.test.tsx
+++ b/frontend/__tests__/login.test.tsx
@@ -103,8 +103,10 @@ describe('LoginPage', () => {
     });
   });
 
-  it('shows error message on failed login', async () => {
-    (login as jest.Mock).mockRejectedValue(new Error('Invalid credentials'));
+  it('shows mapped error message on failed login', async () => {
+    (login as jest.Mock).mockRejectedValue({
+      response: { data: { message: 'Invalid credentials' } },
+    });
 
     render(
       <ThemeProvider>
@@ -120,7 +122,27 @@ describe('LoginPage', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /login/i }));
 
-    expect(await screen.findByText(/login failed/i)).toBeInTheDocument();
+    expect(await screen.findByText(/invalid email\/username or password/i)).toBeInTheDocument();
+  });
+
+  it('shows fallback error message for unexpected failures', async () => {
+    (login as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+    render(
+      <ThemeProvider>
+        <LoginPage />
+      </ThemeProvider>
+    );
+
+    fireEvent.change(screen.getByLabelText(/email or username/i), {
+      target: { value: 'testuser' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i, { selector: 'input' }), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+
+    expect(await screen.findByText(/something went wrong/i)).toBeInTheDocument();
   });
 
   it('has link to register page', () => {

--- a/frontend/__tests__/register.test.tsx
+++ b/frontend/__tests__/register.test.tsx
@@ -110,8 +110,10 @@ describe('RegisterPage', () => {
     });
   });
 
-  it('shows error message on failed registration', async () => {
-    (register as jest.Mock).mockRejectedValue(new Error('Registration failed'));
+  it('shows mapped error message on failed registration', async () => {
+    (register as jest.Mock).mockRejectedValue({
+      response: { data: { message: 'Email or username already taken' } },
+    });
 
     render(
       <ThemeProvider>
@@ -130,7 +132,30 @@ describe('RegisterPage', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /register/i }));
 
-    expect(await screen.findByText(/registration failed/i)).toBeInTheDocument();
+    expect(await screen.findByText(/already registered/i)).toBeInTheDocument();
+  });
+
+  it('shows fallback error message for unexpected failures', async () => {
+    (register as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+    render(
+      <ThemeProvider>
+        <RegisterPage />
+      </ThemeProvider>
+    );
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'test@test.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/username/i), {
+      target: { value: 'testuser' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i, { selector: 'input' }), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /register/i }));
+
+    expect(await screen.findByText(/something went wrong/i)).toBeInTheDocument();
   });
 
   it('has link to login page', () => {

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { login } from '@/lib/authService';
 import { setToken, setUsername } from '@/lib/auth';
+import { getErrorMessage } from '@/lib/errorMessages';
 import ThemeToggle from '@/components/ui/ThemeToggle';
 import Button from '@/components/ui/Button';
 import Input from '@/components/ui/Input';
@@ -30,8 +31,8 @@ function LoginContent() {
       setToken(response.token);
       setUsername(response.username);
       router.push('/dashboard');
-    } catch {
-      setError('Login failed. Please check your credentials.');
+    } catch (err) {
+      setError(getErrorMessage(err));
     } finally {
       setLoading(false);
     }

--- a/frontend/app/(auth)/register/page.tsx
+++ b/frontend/app/(auth)/register/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { register } from '@/lib/authService';
 import { setToken, setUsername as persistUsername } from '@/lib/auth';
+import { getErrorMessage } from '@/lib/errorMessages';
 import ThemeToggle from '@/components/ui/ThemeToggle';
 import Button from '@/components/ui/Button';
 import Input from '@/components/ui/Input';
@@ -41,8 +42,8 @@ export default function RegisterPage() {
       setToken(response.token);
       persistUsername(response.username);
       router.push('/dashboard');
-    } catch {
-      setError('Registration failed. Email or username may already be taken.');
+    } catch (err) {
+      setError(getErrorMessage(err));
     } finally {
       setLoading(false);
     }

--- a/frontend/lib/errorMessages.ts
+++ b/frontend/lib/errorMessages.ts
@@ -1,0 +1,29 @@
+import { ApiError } from '@/types';
+
+const MESSAGE_MAP: Array<[pattern: string, friendly: string]> = [
+    ['invalid credentials', 'Invalid email/username or password.'],
+    ['email or username already taken', 'This email or username is already registered.'],
+    ['application not found', 'This application no longer exists.'],
+    ['access denied', "You don't have permission to do this."],
+];
+
+export const FALLBACK_ERROR = 'Something went wrong. Please try again.';
+
+/**
+ * Extracts a user-friendly message from an Axios error (or any unknown thrown value).
+ * Reads `error.response.data.message` (the backend's ErrorResponse shape) and maps
+ * known substrings to friendly strings. Falls back to FALLBACK_ERROR for anything else.
+ */
+export function getErrorMessage(error: unknown): string {
+    if (error && typeof error === 'object' && 'response' in error) {
+        const data = (error as { response?: { data?: ApiError } }).response?.data;
+        const message = data?.message;
+        if (typeof message === 'string') {
+            const lower = message.toLowerCase();
+            for (const [pattern, friendly] of MESSAGE_MAP) {
+                if (lower.includes(pattern)) return friendly;
+            }
+        }
+    }
+    return FALLBACK_ERROR;
+}


### PR DESCRIPTION
- lib/errorMessages.ts: getErrorMessage() reads error.response.data.message, matches against known backend substrings (case-insensitive), returns friendly strings; falls back to FALLBACK_ERROR for unknown/missing messages
- login/page.tsx, register/page.tsx: catch blocks now call getErrorMessage(err) instead of returning hardcoded strings
- login/register tests: updated error tests to use realistic Axios-style error objects and assert mapped messages; added fallback tests for plain Errors
- lib.errorMessages.test.ts: 11 unit tests covering all mappings, edge cases (null, undefined, missing response, non-string message), and case-insensitivity