### PR TITLE
feat(frontend): add StatsBar with stats endpoint integration (Task 16)

### DIFF
--- a/frontend/__tests__/dashboard.statsBar.test.tsx
+++ b/frontend/__tests__/dashboard.statsBar.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+import StatsBar from '@/components/dashboard/StatsBar';
+import { StatsResponse } from '@/types';
+
+const mockStats: StatsResponse = {
+    totalApplications: 10,
+    statusBreakdown: {
+        APPLIED: 3,
+        SCREENING: 2,
+        INTERVIEWING: 1,
+        OFFER: 1,
+        REJECTED: 2,
+        WITHDRAWN: 1,
+    },
+    monthlyApplications: [],
+    responseRate: 0.6,
+};
+
+describe('StatsBar', () => {
+    it('renders total applications count', () => {
+        render(<StatsBar stats={mockStats} />);
+        expect(screen.getByText('10')).toBeInTheDocument();
+        expect(screen.getByText(/total applications/i)).toBeInTheDocument();
+    });
+
+    it('renders all status breakdown counts', () => {
+        render(<StatsBar stats={mockStats} />);
+        expect(screen.getByText('3')).toBeInTheDocument();                   // APPLIED
+        expect(screen.getAllByText('2')).toHaveLength(2);                    // SCREENING + REJECTED
+        expect(screen.getAllByText('1')).toHaveLength(3);                    // INTERVIEWING + OFFER + WITHDRAWN
+    });
+
+    it('renders all status labels', () => {
+        render(<StatsBar stats={mockStats} />);
+        expect(screen.getByText('Applied')).toBeInTheDocument();
+        expect(screen.getByText('Screening')).toBeInTheDocument();
+        expect(screen.getByText('Interviewing')).toBeInTheDocument();
+        expect(screen.getByText('Offer')).toBeInTheDocument();
+        expect(screen.getByText('Rejected')).toBeInTheDocument();
+        expect(screen.getByText('Withdrawn')).toBeInTheDocument();
+    });
+
+    it('renders response rate as a percentage', () => {
+        render(<StatsBar stats={mockStats} />);
+        expect(screen.getByText('60%')).toBeInTheDocument();
+        expect(screen.getByText(/of applications received a response/i)).toBeInTheDocument();
+    });
+
+    it('renders the response rate progress bar with correct width', () => {
+        render(<StatsBar stats={mockStats} />);
+        const progressBar = screen.getByRole('progressbar');
+        expect(progressBar).toHaveAttribute('aria-valuenow', '60');
+        expect(progressBar).toHaveAttribute('aria-valuemin', '0');
+        expect(progressBar).toHaveAttribute('aria-valuemax', '100');
+        // The fill div is the direct child
+        const fill = progressBar.firstChild as HTMLElement;
+        expect(fill).toHaveStyle({ width: '60%' });
+    });
+
+    it('shows 0 for statuses missing from statusBreakdown', () => {
+        const statsWithMissing: StatsResponse = {
+            ...mockStats,
+            statusBreakdown: { APPLIED: 5 },
+        };
+        render(<StatsBar stats={statsWithMissing} />);
+        // 5 statuses should show 0
+        const zeros = screen.getAllByText('0');
+        expect(zeros).toHaveLength(5);
+    });
+
+    it('rounds the response rate to the nearest integer', () => {
+        const statsWithDecimal: StatsResponse = {
+            ...mockStats,
+            responseRate: 0.333,
+        };
+        render(<StatsBar stats={statsWithDecimal} />);
+        expect(screen.getByText('33%')).toBeInTheDocument();
+    });
+
+    it('shows 0% response rate when responseRate is 0', () => {
+        const statsZero: StatsResponse = {
+            ...mockStats,
+            responseRate: 0,
+        };
+        render(<StatsBar stats={statsZero} />);
+        expect(screen.getByText('0%')).toBeInTheDocument();
+        const progressBar = screen.getByRole('progressbar');
+        const fill = progressBar.firstChild as HTMLElement;
+        expect(fill).toHaveStyle({ width: '0%' });
+    });
+});

--- a/frontend/__tests__/dashboard.test.tsx
+++ b/frontend/__tests__/dashboard.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { useRouter } from 'next/navigation';
 import DashboardPage from '@/app/(app)/dashboard/page';
-import { getApplications } from '@/lib/applicationService';
+import { getApplications, getStats } from '@/lib/applicationService';
 import { isAuthenticated } from '@/lib/auth';
-import { Application } from '@/types';
+import { Application, StatsResponse } from '@/types';
 
 // Mock the modules
 jest.mock('next/navigation', () => ({
@@ -12,6 +12,7 @@ jest.mock('next/navigation', () => ({
 
 jest.mock('@/lib/applicationService', () => ({
   getApplications: jest.fn(),
+  getStats: jest.fn(),
 }));
 
 jest.mock('@/lib/auth', () => ({
@@ -48,6 +49,13 @@ const mockApplications: Application[] = [
   },
 ];
 
+const mockStats: StatsResponse = {
+  totalApplications: 2,
+  statusBreakdown: { APPLIED: 1, INTERVIEWING: 1 },
+  monthlyApplications: [],
+  responseRate: 0.5,
+};
+
 describe('DashboardPage', () => {
   const mockPush = jest.fn();
 
@@ -56,6 +64,7 @@ describe('DashboardPage', () => {
     (useRouter as jest.Mock).mockReturnValue({
       push: mockPush,
     });
+    (getStats as jest.Mock).mockResolvedValue(mockStats);
   });
 
   it('redirects to login if not authenticated', async () => {

--- a/frontend/app/(app)/dashboard/page.tsx
+++ b/frontend/app/(app)/dashboard/page.tsx
@@ -2,13 +2,15 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { getApplications } from '@/lib/applicationService';
+import { getApplications, getStats } from '@/lib/applicationService';
 import { isAuthenticated, removeToken, removeUsername } from '@/lib/auth';
-import { Application } from '@/types';
+import { Application, StatsResponse } from '@/types';
+import StatsBar from '@/components/dashboard/StatsBar';
 
 export default function DashboardPage() {
   const router = useRouter();
   const [applications, setApplications] = useState<Application[]>([]);
+  const [stats, setStats] = useState<StatsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
@@ -18,10 +20,11 @@ export default function DashboardPage() {
       return;
     }
 
-    const fetchApplications = async () => {
+    const fetchData = async () => {
       try {
-        const data = await getApplications();
+        const [data, statsData] = await Promise.all([getApplications(), getStats()]);
         setApplications(data);
+        setStats(statsData);
       } catch {
         setError('Failed to load applications');
       } finally {
@@ -29,7 +32,7 @@ export default function DashboardPage() {
       }
     };
 
-    fetchApplications();
+    fetchData();
   }, [router]);
 
   const handleLogout = () => {
@@ -72,12 +75,14 @@ export default function DashboardPage() {
         </div>
       </header>
 
-      <main className="max-w-7xl mx-auto px-4 py-8">
+      <main className="max-w-7xl mx-auto px-4 py-8 space-y-6">
         {error && (
-          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
             {error}
           </div>
         )}
+
+        {stats && <StatsBar stats={stats} />}
 
         {applications.length === 0 ? (
           <div className="bg-white rounded-lg shadow p-8 text-center">

--- a/frontend/components/dashboard/StatsBar.tsx
+++ b/frontend/components/dashboard/StatsBar.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { StatsResponse, Status } from '@/types';
+
+interface StatusConfig {
+    label: string;
+    bg: string;
+    text: string;
+}
+
+const STATUS_CONFIG: Record<Status, StatusConfig> = {
+    APPLIED:      { label: 'Applied',      bg: 'bg-blue-100   dark:bg-blue-900/40',    text: 'text-blue-800   dark:text-blue-300'   },
+    SCREENING:    { label: 'Screening',    bg: 'bg-purple-100 dark:bg-purple-900/40',  text: 'text-purple-800 dark:text-purple-300' },
+    INTERVIEWING: { label: 'Interviewing', bg: 'bg-amber-100  dark:bg-amber-900/40',   text: 'text-amber-800  dark:text-amber-300'  },
+    OFFER:        { label: 'Offer',        bg: 'bg-green-100  dark:bg-green-900/40',   text: 'text-green-800  dark:text-green-300'  },
+    REJECTED:     { label: 'Rejected',     bg: 'bg-red-100    dark:bg-red-900/40',     text: 'text-red-800    dark:text-red-300'    },
+    WITHDRAWN:    { label: 'Withdrawn',    bg: 'bg-[var(--muted)]',                    text: 'text-[var(--muted-foreground)]'       },
+};
+
+const STATUS_ORDER: Status[] = ['APPLIED', 'SCREENING', 'INTERVIEWING', 'OFFER', 'REJECTED', 'WITHDRAWN'];
+
+interface StatsBarProps {
+    stats: StatsResponse;
+}
+
+export default function StatsBar({ stats }: StatsBarProps) {
+    const responseRatePct = Math.round(stats.responseRate * 100);
+
+    return (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+            {/* Total Applications */}
+            <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5">
+                <p className="text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
+                    Total Applications
+                </p>
+                <p className="mt-1 text-3xl font-bold text-[var(--card-foreground)] leading-none">
+                    {stats.totalApplications}
+                </p>
+            </div>
+
+            {/* Status Breakdown */}
+            <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5">
+                <p className="text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)] mb-3">
+                    Status Breakdown
+                </p>
+                <div className="grid grid-cols-3 gap-2">
+                    {STATUS_ORDER.map((status) => {
+                        const { label, bg, text } = STATUS_CONFIG[status];
+                        const count = stats.statusBreakdown[status] ?? 0;
+                        return (
+                            <div key={status} className={`rounded-lg p-2 ${bg}`}>
+                                <p className={`text-lg font-bold leading-none ${text}`}>{count}</p>
+                                <p className={`mt-0.5 text-xs ${text}`}>{label}</p>
+                            </div>
+                        );
+                    })}
+                </div>
+            </div>
+
+            {/* Response Rate */}
+            <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5">
+                <p className="text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
+                    Response Rate
+                </p>
+                <p className="mt-1 text-3xl font-bold text-[var(--card-foreground)] leading-none">
+                    {responseRatePct}%
+                </p>
+                <div
+                    role="progressbar"
+                    aria-valuenow={responseRatePct}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-label="Response rate progress"
+                    className="mt-3 h-2 rounded-full bg-[var(--muted)] overflow-hidden"
+                >
+                    <div
+                        className="h-full rounded-full bg-[var(--primary)] transition-all duration-500"
+                        style={{ width: `${responseRatePct}%` }}
+                    />
+                </div>
+                <p className="mt-1.5 text-xs text-[var(--muted-foreground)]">
+                    of applications received a response
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/frontend/lib/applicationService.ts
+++ b/frontend/lib/applicationService.ts
@@ -1,5 +1,5 @@
 import api from './api';
-import { Application } from '@/types';
+import { Application, StatsResponse } from '@/types';
 
 export const getApplications = async (): Promise<Application[]> => {
   const response = await api.get<{ content: Application[] }>('/applications');
@@ -23,4 +23,9 @@ export const updateApplication = async (id: string, data: Partial<Application>):
 
 export const deleteApplication = async (id: string): Promise<void> => {
   await api.delete(`/applications/${id}`);
+};
+
+export const getStats = async (): Promise<StatsResponse> => {
+  const response = await api.get<StatsResponse>('/applications/stats');
+  return response.data;
 };

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -62,3 +62,17 @@ export interface UpdateProfileRequest {
     password?: string;
     themePreference?: ThemePreference;
 }
+
+// Mirrors MonthlyCount DTO from GET /applications/stats
+export interface MonthlyCount {
+    month: string;
+    count: number;
+}
+
+// Mirrors ApplicationStatsResponse DTO from GET /applications/stats
+export interface StatsResponse {
+    totalApplications: number;
+    statusBreakdown: Partial<Record<Status, number>>;
+    monthlyApplications: MonthlyCount[];
+    responseRate: number;
+}


### PR DESCRIPTION
- Add MonthlyCount and StatsResponse types to types/index.ts
- Add getStats() to applicationService.ts calling GET /applications/stats
- Create components/dashboard/StatsBar.tsx with total, status breakdown mini-cards (color-coded), and response rate progress bar
- Update dashboard page to fetch stats and render StatsBar above table
- Add 8 tests for StatsBar; update dashboard.test.tsx to mock getStats