### PR TITLE
feat(frontend): add dashboard charts with Recharts (Task 17)

### DIFF
--- a/frontend/__tests__/dashboard.applicationsChart.test.tsx
+++ b/frontend/__tests__/dashboard.applicationsChart.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import ApplicationsChart, { formatMonth } from '@/components/dashboard/ApplicationsChart';
+import { MonthlyCount } from '@/types';
+
+jest.mock('recharts', () => ({
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    BarChart: ({ children }: { children: React.ReactNode }) => <div data-testid="bar-chart">{children}</div>,
+    Bar: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+    CartesianGrid: () => null,
+    Tooltip: () => null,
+}));
+
+jest.mock('@/context/ThemeContext', () => ({
+    useTheme: () => ({ resolvedTheme: 'light' }),
+}));
+
+const mockData: MonthlyCount[] = [
+    { month: '2026-01', count: 5 },
+    { month: '2026-02', count: 3 },
+    { month: '2026-03', count: 8 },
+];
+
+describe('formatMonth', () => {
+    it('formats YYYY-MM to "Mon \'YY"', () => {
+        expect(formatMonth('2026-01')).toBe("Jan '26");
+        expect(formatMonth('2026-12')).toBe("Dec '26");
+        expect(formatMonth('2025-07')).toBe("Jul '25");
+    });
+});
+
+describe('ApplicationsChart', () => {
+    it('renders the bar chart when data is provided', () => {
+        render(<ApplicationsChart data={mockData} />);
+        expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+    });
+
+    it('renders the chart title', () => {
+        render(<ApplicationsChart data={mockData} />);
+        expect(screen.getByText(/applications by month/i)).toBeInTheDocument();
+    });
+
+    it('shows empty state when data is empty', () => {
+        render(<ApplicationsChart data={[]} />);
+        expect(screen.getByText(/no monthly data yet/i)).toBeInTheDocument();
+        expect(screen.queryByTestId('bar-chart')).not.toBeInTheDocument();
+    });
+
+    it('renders correctly in dark theme', () => {
+        jest.resetModules();
+        jest.mock('@/context/ThemeContext', () => ({
+            useTheme: () => ({ resolvedTheme: 'dark' }),
+        }));
+        render(<ApplicationsChart data={mockData} />);
+        expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+    });
+});

--- a/frontend/__tests__/dashboard.statusChart.test.tsx
+++ b/frontend/__tests__/dashboard.statusChart.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import StatusChart from '@/components/dashboard/StatusChart';
+
+jest.mock('recharts', () => ({
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    PieChart: ({ children }: { children: React.ReactNode }) => <div data-testid="pie-chart">{children}</div>,
+    Pie: ({ data }: { data: { name: string }[] }) => (
+        <div data-testid="pie" data-slices={data?.length ?? 0} />
+    ),
+    Cell: () => null,
+    Tooltip: () => null,
+    Legend: ({ formatter }: { formatter: (v: string) => React.ReactNode }) => (
+        <div data-testid="legend">{['Applied', 'Rejected'].map((v) => <span key={v}>{formatter(v)}</span>)}</div>
+    ),
+}));
+
+jest.mock('@/context/ThemeContext', () => ({
+    useTheme: () => ({ resolvedTheme: 'light' }),
+}));
+
+describe('StatusChart', () => {
+    it('renders the pie chart when there is data', () => {
+        render(<StatusChart statusBreakdown={{ APPLIED: 3, REJECTED: 2 }} />);
+        expect(screen.getByTestId('pie-chart')).toBeInTheDocument();
+    });
+
+    it('renders the chart title', () => {
+        render(<StatusChart statusBreakdown={{ APPLIED: 3 }} />);
+        expect(screen.getByText(/status breakdown/i)).toBeInTheDocument();
+    });
+
+    it('shows empty state when all counts are zero', () => {
+        render(<StatusChart statusBreakdown={{ APPLIED: 0, REJECTED: 0 }} />);
+        expect(screen.getByText(/no applications yet/i)).toBeInTheDocument();
+        expect(screen.queryByTestId('pie-chart')).not.toBeInTheDocument();
+    });
+
+    it('shows empty state when statusBreakdown is empty', () => {
+        render(<StatusChart statusBreakdown={{}} />);
+        expect(screen.getByText(/no applications yet/i)).toBeInTheDocument();
+    });
+
+    it('filters out zero-count statuses from pie slices', () => {
+        render(<StatusChart statusBreakdown={{ APPLIED: 5, SCREENING: 0, REJECTED: 2 }} />);
+        const pie = screen.getByTestId('pie');
+        // Only APPLIED and REJECTED have non-zero counts
+        expect(pie).toHaveAttribute('data-slices', '2');
+    });
+
+    it('renders legend with status labels', () => {
+        render(<StatusChart statusBreakdown={{ APPLIED: 3, REJECTED: 2 }} />);
+        expect(screen.getByTestId('legend')).toBeInTheDocument();
+        expect(screen.getByText('Applied')).toBeInTheDocument();
+        expect(screen.getByText('Rejected')).toBeInTheDocument();
+    });
+});

--- a/frontend/__tests__/dashboard.test.tsx
+++ b/frontend/__tests__/dashboard.test.tsx
@@ -20,6 +20,9 @@ jest.mock('@/lib/auth', () => ({
   removeToken: jest.fn(),
 }));
 
+jest.mock('@/components/dashboard/ApplicationsChart', () => function ApplicationsChart() { return <div data-testid="applications-chart" />; });
+jest.mock('@/components/dashboard/StatusChart', () => function StatusChart() { return <div data-testid="status-chart" />; });
+
 const mockApplications: Application[] = [
   {
     id: '1',

--- a/frontend/app/(app)/dashboard/page.tsx
+++ b/frontend/app/(app)/dashboard/page.tsx
@@ -6,6 +6,8 @@ import { getApplications, getStats } from '@/lib/applicationService';
 import { isAuthenticated, removeToken, removeUsername } from '@/lib/auth';
 import { Application, StatsResponse } from '@/types';
 import StatsBar from '@/components/dashboard/StatsBar';
+import ApplicationsChart from '@/components/dashboard/ApplicationsChart';
+import StatusChart from '@/components/dashboard/StatusChart';
 
 export default function DashboardPage() {
   const router = useRouter();
@@ -82,7 +84,15 @@ export default function DashboardPage() {
           </div>
         )}
 
-        {stats && <StatsBar stats={stats} />}
+        {stats && (
+          <>
+            <StatsBar stats={stats} />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <ApplicationsChart data={stats.monthlyApplications} />
+              <StatusChart statusBreakdown={stats.statusBreakdown} />
+            </div>
+          </>
+        )}
 
         {applications.length === 0 ? (
           <div className="bg-white rounded-lg shadow p-8 text-center">

--- a/frontend/components/dashboard/ApplicationsChart.tsx
+++ b/frontend/components/dashboard/ApplicationsChart.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+    BarChart, Bar, XAxis, YAxis, CartesianGrid,
+    Tooltip, ResponsiveContainer,
+} from 'recharts';
+import { useTheme } from '@/context/ThemeContext';
+import { MonthlyCount } from '@/types';
+
+const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+export function formatMonth(month: string): string {
+    const [year, m] = month.split('-');
+    return `${MONTH_LABELS[parseInt(m, 10) - 1]} '${year.slice(2)}`;
+}
+
+interface ApplicationsChartProps {
+    data: MonthlyCount[];
+}
+
+export default function ApplicationsChart({ data }: ApplicationsChartProps) {
+    const { resolvedTheme } = useTheme();
+
+    const colors = useMemo(() => (
+        resolvedTheme === 'dark'
+            ? { axis: '#a3a3a3', grid: '#2e2e2e', tooltipBg: '#1a1a1a', tooltipBorder: '#2e2e2e', tooltipText: '#ededed', bar: '#3b82f6', cursor: '#2e2e2e' }
+            : { axis: '#737373', grid: '#e5e5e5', tooltipBg: '#ffffff', tooltipBorder: '#e5e5e5', tooltipText: '#171717', bar: '#2563eb', cursor: '#f5f5f5' }
+    ), [resolvedTheme]);
+
+    const chartData = useMemo(
+        () => data.map((d) => ({ ...d, month: formatMonth(d.month) })),
+        [data],
+    );
+
+    if (data.length === 0) {
+        return (
+            <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5 flex items-center justify-center h-64">
+                <p className="text-sm text-[var(--muted-foreground)]">No monthly data yet</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5">
+            <p className="text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)] mb-4">
+                Applications by Month
+            </p>
+            <ResponsiveContainer width="100%" height={220}>
+                <BarChart data={chartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke={colors.grid} vertical={false} />
+                    <XAxis
+                        dataKey="month"
+                        tick={{ fontSize: 11, fill: colors.axis }}
+                        tickLine={false}
+                        axisLine={false}
+                    />
+                    <YAxis
+                        allowDecimals={false}
+                        tick={{ fontSize: 11, fill: colors.axis }}
+                        tickLine={false}
+                        axisLine={false}
+                    />
+                    <Tooltip
+                        contentStyle={{
+                            backgroundColor: colors.tooltipBg,
+                            border: `1px solid ${colors.tooltipBorder}`,
+                            borderRadius: '8px',
+                            color: colors.tooltipText,
+                            fontSize: 12,
+                        }}
+                        cursor={{ fill: colors.cursor }}
+                    />
+                    <Bar dataKey="count" fill={colors.bar} radius={[4, 4, 0, 0]} name="Applications" />
+                </BarChart>
+            </ResponsiveContainer>
+        </div>
+    );
+}

--- a/frontend/components/dashboard/StatusChart.tsx
+++ b/frontend/components/dashboard/StatusChart.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useMemo } from 'react';
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { useTheme } from '@/context/ThemeContext';
+import { Status } from '@/types';
+
+const STATUS_COLORS: Record<Status, string> = {
+    APPLIED:      '#3b82f6',
+    SCREENING:    '#a855f7',
+    INTERVIEWING: '#f59e0b',
+    OFFER:        '#22c55e',
+    REJECTED:     '#ef4444',
+    WITHDRAWN:    '#6b7280',
+};
+
+const STATUS_LABELS: Record<Status, string> = {
+    APPLIED:      'Applied',
+    SCREENING:    'Screening',
+    INTERVIEWING: 'Interviewing',
+    OFFER:        'Offer',
+    REJECTED:     'Rejected',
+    WITHDRAWN:    'Withdrawn',
+};
+
+const STATUS_ORDER: Status[] = ['APPLIED', 'SCREENING', 'INTERVIEWING', 'OFFER', 'REJECTED', 'WITHDRAWN'];
+
+interface StatusChartProps {
+    statusBreakdown: Partial<Record<Status, number>>;
+}
+
+export default function StatusChart({ statusBreakdown }: StatusChartProps) {
+    const { resolvedTheme } = useTheme();
+
+    const tooltipColors = useMemo(() => (
+        resolvedTheme === 'dark'
+            ? { bg: '#1a1a1a', border: '#2e2e2e', text: '#ededed' }
+            : { bg: '#ffffff', border: '#e5e5e5', text: '#171717' }
+    ), [resolvedTheme]);
+
+    const legendColor = resolvedTheme === 'dark' ? '#a3a3a3' : '#737373';
+
+    const chartData = useMemo(
+        () => STATUS_ORDER
+            .filter((s) => (statusBreakdown[s] ?? 0) > 0)
+            .map((s) => ({
+                name: STATUS_LABELS[s],
+                value: statusBreakdown[s]!,
+                color: STATUS_COLORS[s],
+            })),
+        [statusBreakdown],
+    );
+
+    if (chartData.length === 0) {
+        return (
+            <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5 flex items-center justify-center h-64">
+                <p className="text-sm text-[var(--muted-foreground)]">No applications yet</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5">
+            <p className="text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)] mb-4">
+                Status Breakdown
+            </p>
+            <ResponsiveContainer width="100%" height={220}>
+                <PieChart>
+                    <Pie
+                        data={chartData}
+                        cx="50%"
+                        cy="50%"
+                        innerRadius={55}
+                        outerRadius={85}
+                        paddingAngle={2}
+                        dataKey="value"
+                    >
+                        {chartData.map((entry) => (
+                            <Cell key={entry.name} fill={entry.color} stroke="none" />
+                        ))}
+                    </Pie>
+                    <Tooltip
+                        contentStyle={{
+                            backgroundColor: tooltipColors.bg,
+                            border: `1px solid ${tooltipColors.border}`,
+                            borderRadius: '8px',
+                            color: tooltipColors.text,
+                            fontSize: 12,
+                        }}
+                    />
+                    <Legend
+                        iconType="circle"
+                        iconSize={8}
+                        formatter={(value) => (
+                            <span style={{ fontSize: 12, color: legendColor }}>{value}</span>
+                        )}
+                    />
+                </PieChart>
+            </ResponsiveContainer>
+        </div>
+    );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "axios": "^1.13.2",
         "next": "16.1.3",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "recharts": "^3.7.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -2261,6 +2262,42 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2294,6 +2331,18 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -2723,6 +2772,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2843,7 +2955,7 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2883,6 +2995,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -4206,6 +4324,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -4310,8 +4437,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4411,6 +4659,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -4797,6 +5051,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.0.tgz",
+      "integrity": "sha512-RArCX+Zea16+R1jg4mH223Z8p/ivbJjIkU3oC6ld2bdUfmDxiCkFYSi9zLOR2anucWJUeH4Djnzgd0im0nD3dw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -5260,6 +5524,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -6005,6 +6275,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6094,6 +6374,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -9116,8 +9405,62 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -9131,6 +9474,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -9186,6 +9545,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -10107,6 +10472,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -10522,6 +10893,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -10535,6 +10915,28 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "axios": "^1.13.2",
     "next": "16.1.3",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "recharts": "^3.7.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
- Install recharts@3.7.0
- `ApplicationsChart.tsx` — BarChart grouped by month, theme-aware colors via `useTheme()`; export `formatMonth` for unit testing
- `StatusChart.tsx` — donut PieChart with per-status colors, filters zero-count slices, theme-aware tooltip
- Wire both charts into dashboard page below StatsBar in a responsive `grid-cols-1 md:grid-cols-2` layout
- Add 11 tests (formatMonth unit tests, chart rendering, empty states, zero-filtering); mock recharts and chart components in dashboard.test.tsx
- 168 tests passing, lint clean