### PR TITLE
feat(frontend): add server-side paginated ApplicationsTable (Task 18a)

### DIFF
--- a/frontend/__tests__/applications.table.test.tsx
+++ b/frontend/__tests__/applications.table.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import ApplicationsTable from '@/components/applications/ApplicationsTable';
+import { getApplications } from '@/lib/applicationService';
+import { Application, PagedResponse } from '@/types';
+
+jest.mock('@/lib/applicationService', () => ({
+    getApplications: jest.fn(),
+}));
+
+const mockGetApplications = getApplications as jest.Mock;
+
+const makeApp = (overrides: Partial<Application> = {}): Application => ({
+    id: '1',
+    companyName: 'Acme Corp',
+    jobRole: 'Software Engineer',
+    status: 'APPLIED',
+    appliedDate: '2026-01-15',
+    location: 'Remote',
+    jobType: 'FULL_TIME',
+    statusChangedDate: null,
+    websiteLink: null,
+    username: null,
+    password: null,
+    ...overrides,
+});
+
+const makePage = (
+    apps: Application[],
+    overrides: Partial<PagedResponse<Application>> = {},
+): PagedResponse<Application> => ({
+    content: apps,
+    totalElements: apps.length,
+    totalPages: 1,
+    number: 0,
+    size: 20,
+    first: true,
+    last: true,
+    ...overrides,
+});
+
+describe('ApplicationsTable', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('shows loading spinner initially', () => {
+        mockGetApplications.mockReturnValue(new Promise(() => {}));
+        render(<ApplicationsTable />);
+        expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
+    });
+
+    it('renders all column headers after load', async () => {
+        mockGetApplications.mockResolvedValue(makePage([makeApp()]));
+        render(<ApplicationsTable />);
+        await waitFor(() =>
+            expect(screen.getByRole('columnheader', { name: /company/i })).toBeInTheDocument(),
+        );
+        expect(screen.getByRole('columnheader', { name: /role/i })).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', { name: /status/i })).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', { name: /applied date/i })).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', { name: /location/i })).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', { name: /job type/i })).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', { name: /credentials/i })).toBeInTheDocument();
+        expect(screen.getByRole('columnheader', { name: /actions/i })).toBeInTheDocument();
+    });
+
+    it('renders application row data', async () => {
+        const apps = [
+            makeApp({ id: '1', companyName: 'Acme Corp', jobRole: 'Engineer', appliedDate: '2026-01-15', location: 'Remote' }),
+            makeApp({ id: '2', companyName: 'Beta Inc', jobRole: 'Designer', status: 'OFFER', appliedDate: '2026-02-01', location: 'London' }),
+        ];
+        mockGetApplications.mockResolvedValue(makePage(apps, { totalElements: 2 }));
+        render(<ApplicationsTable />);
+        await waitFor(() => expect(screen.getByText('Acme Corp')).toBeInTheDocument());
+        expect(screen.getByText('Beta Inc')).toBeInTheDocument();
+        expect(screen.getByText('Engineer')).toBeInTheDocument();
+        expect(screen.getByText('Designer')).toBeInTheDocument();
+        expect(screen.getByText('Remote')).toBeInTheDocument();
+        expect(screen.getByText('London')).toBeInTheDocument();
+    });
+
+    it('renders status badges for each row', async () => {
+        const apps = [
+            makeApp({ id: '1', status: 'APPLIED' }),
+            makeApp({ id: '2', status: 'OFFER' }),
+        ];
+        mockGetApplications.mockResolvedValue(makePage(apps, { totalElements: 2 }));
+        render(<ApplicationsTable />);
+        await waitFor(() => expect(screen.getByText('Applied')).toBeInTheDocument());
+        expect(screen.getByText('Offer')).toBeInTheDocument();
+    });
+
+    it('maps job type enum to human-readable label', async () => {
+        mockGetApplications.mockResolvedValue(makePage([makeApp({ jobType: 'FULL_TIME' })]));
+        render(<ApplicationsTable />);
+        await waitFor(() => expect(screen.getByText('Full-time')).toBeInTheDocument());
+    });
+
+    it('shows masked credentials when username or password is present', async () => {
+        mockGetApplications.mockResolvedValue(
+            makePage([makeApp({ username: 'user123', password: 'secret' })]),
+        );
+        render(<ApplicationsTable />);
+        await waitFor(() => expect(screen.getByText('••••••••')).toBeInTheDocument());
+    });
+
+    it('shows dash in credentials column when no credentials', async () => {
+        mockGetApplications.mockResolvedValue(
+            makePage([makeApp({ username: null, password: null })]),
+        );
+        render(<ApplicationsTable />);
+        await waitFor(() => screen.getByText('Acme Corp'));
+        // Both credentials and actions columns show "—" when there are no credentials
+        expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('shows empty state when no applications', async () => {
+        mockGetApplications.mockResolvedValue(makePage([], { totalElements: 0 }));
+        render(<ApplicationsTable />);
+        await waitFor(() =>
+            expect(screen.getByText(/no applications yet/i)).toBeInTheDocument(),
+        );
+    });
+
+    it('shows error message and retry button on fetch failure', async () => {
+        mockGetApplications.mockRejectedValue(new Error('Network error'));
+        render(<ApplicationsTable />);
+        await waitFor(() =>
+            expect(screen.getByText(/failed to load applications/i)).toBeInTheDocument(),
+        );
+        expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    });
+
+    it('retries fetch when retry button is clicked', async () => {
+        mockGetApplications
+            .mockRejectedValueOnce(new Error('Network error'))
+            .mockResolvedValue(makePage([makeApp()]));
+        render(<ApplicationsTable />);
+        await waitFor(() => screen.getByRole('button', { name: /retry/i }));
+        fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+        await waitFor(() => expect(screen.getByText('Acme Corp')).toBeInTheDocument());
+    });
+
+    it('does not render pagination when only one page', async () => {
+        mockGetApplications.mockResolvedValue(makePage([makeApp()], { totalPages: 1 }));
+        render(<ApplicationsTable />);
+        await waitFor(() => screen.getByText('Acme Corp'));
+        expect(screen.queryByRole('button', { name: /previous page/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /next page/i })).not.toBeInTheDocument();
+    });
+
+    it('renders pagination controls when multiple pages exist', async () => {
+        const apps = Array.from({ length: 20 }, (_, i) =>
+            makeApp({ id: String(i), companyName: `Company ${i}` }),
+        );
+        mockGetApplications.mockResolvedValue(
+            makePage(apps, { totalPages: 3, totalElements: 60, size: 20 }),
+        );
+        render(<ApplicationsTable />);
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: /next page/i })).toBeInTheDocument(),
+        );
+        expect(screen.getByRole('button', { name: /previous page/i })).toBeInTheDocument();
+    });
+
+    it('calls getApplications with page=0, size=20, sort on mount', async () => {
+        mockGetApplications.mockResolvedValue(makePage([makeApp()]));
+        render(<ApplicationsTable />);
+        await waitFor(() => screen.getByText('Acme Corp'));
+        expect(mockGetApplications).toHaveBeenCalledWith(0, 20, 'appliedDate,desc');
+    });
+});

--- a/frontend/__tests__/dashboard.test.tsx
+++ b/frontend/__tests__/dashboard.test.tsx
@@ -1,62 +1,37 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { useRouter } from 'next/navigation';
 import DashboardPage from '@/app/(app)/dashboard/page';
-import { getApplications, getStats } from '@/lib/applicationService';
+import { getStats } from '@/lib/applicationService';
 import { isAuthenticated } from '@/lib/auth';
-import { Application, StatsResponse } from '@/types';
+import { StatsResponse } from '@/types';
 
-// Mock the modules
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
 }));
 
 jest.mock('@/lib/applicationService', () => ({
-  getApplications: jest.fn(),
   getStats: jest.fn(),
 }));
 
 jest.mock('@/lib/auth', () => ({
   isAuthenticated: jest.fn(),
-  removeToken: jest.fn(),
 }));
 
-jest.mock('@/components/dashboard/ApplicationsChart', () => function ApplicationsChart() { return <div data-testid="applications-chart" />; });
-jest.mock('@/components/dashboard/StatusChart', () => function StatusChart() { return <div data-testid="status-chart" />; });
-
-const mockApplications: Application[] = [
-  {
-    id: '1',
-    companyName: 'Google',
-    jobType: 'FULL_TIME',
-    location: 'Tel Aviv',
-    jobRole: 'Developer',
-    appliedDate: '2026-01-20',
-    status: 'APPLIED',
-    statusChangedDate: null,
-    websiteLink: 'https://google.com',
-    username: null,
-    password: null,
-  },
-  {
-    id: '2',
-    companyName: 'Microsoft',
-    jobType: 'FULL_TIME',
-    location: 'Herzliya',
-    jobRole: 'Engineer',
-    appliedDate: '2026-01-21',
-    status: 'INTERVIEWING',
-    statusChangedDate: null,
-    websiteLink: 'https://microsoft.com',
-    username: null,
-    password: null,
-  },
-];
+jest.mock('@/components/dashboard/ApplicationsChart', () =>
+  function ApplicationsChart() { return <div data-testid="applications-chart" />; },
+);
+jest.mock('@/components/dashboard/StatusChart', () =>
+  function StatusChart() { return <div data-testid="status-chart" />; },
+);
+jest.mock('@/components/applications/ApplicationsTable', () =>
+  function ApplicationsTable() { return <div data-testid="applications-table" />; },
+);
 
 const mockStats: StatsResponse = {
-  totalApplications: 2,
-  statusBreakdown: { APPLIED: 1, INTERVIEWING: 1 },
+  totalApplications: 5,
+  statusBreakdown: { APPLIED: 3, OFFER: 2 },
   monthlyApplications: [],
-  responseRate: 0.5,
+  responseRate: 0.4,
 };
 
 describe('DashboardPage', () => {
@@ -64,88 +39,48 @@ describe('DashboardPage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (useRouter as jest.Mock).mockReturnValue({
-      push: mockPush,
-    });
-    (getStats as jest.Mock).mockResolvedValue(mockStats);
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
   });
 
-  it('redirects to login if not authenticated', async () => {
+  it('redirects to /login if not authenticated', async () => {
     (isAuthenticated as jest.Mock).mockReturnValue(false);
-
     render(<DashboardPage />);
-
-    await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/login');
-    });
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/login'));
   });
 
-  it('shows loading state initially', () => {
+  it('shows loading spinner initially', () => {
     (isAuthenticated as jest.Mock).mockReturnValue(true);
-    (getApplications as jest.Mock).mockImplementation(() => new Promise(() => {}));
-
+    (getStats as jest.Mock).mockReturnValue(new Promise(() => {}));
     render(<DashboardPage />);
-
-    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument();
   });
 
-  it('displays applications when loaded', async () => {
+  it('renders StatsBar, charts, and table when stats load', async () => {
     (isAuthenticated as jest.Mock).mockReturnValue(true);
-    (getApplications as jest.Mock).mockResolvedValue(mockApplications);
-
+    (getStats as jest.Mock).mockResolvedValue(mockStats);
     render(<DashboardPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Google')).toBeInTheDocument();
-      expect(screen.getByText('Microsoft')).toBeInTheDocument();
-      expect(screen.getByText('Developer')).toBeInTheDocument();
-      expect(screen.getByText('Engineer')).toBeInTheDocument();
-    });
+    await waitFor(() =>
+      expect(screen.getByTestId('applications-chart')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('status-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('applications-table')).toBeInTheDocument();
   });
 
-  it('displays status badges with correct text', async () => {
+  it('always renders ApplicationsTable regardless of stats', async () => {
     (isAuthenticated as jest.Mock).mockReturnValue(true);
-    (getApplications as jest.Mock).mockResolvedValue(mockApplications);
-
+    (getStats as jest.Mock).mockRejectedValue(new Error('stats error'));
     render(<DashboardPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('APPLIED')).toBeInTheDocument();
-      expect(screen.getByText('INTERVIEWING')).toBeInTheDocument();
-    });
+    await waitFor(() =>
+      expect(screen.getByTestId('applications-table')).toBeInTheDocument(),
+    );
   });
 
-  it('shows empty state when no applications exist', async () => {
+  it('shows error message when stats fetch fails', async () => {
     (isAuthenticated as jest.Mock).mockReturnValue(true);
-    (getApplications as jest.Mock).mockResolvedValue([]);
-
+    (getStats as jest.Mock).mockRejectedValue(new Error('Network error'));
     render(<DashboardPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText(/no applications yet/i)).toBeInTheDocument();
-      expect(screen.getByText(/add your first application/i)).toBeInTheDocument();
-    });
-  });
-
-  it('shows error message when fetch fails', async () => {
-    (isAuthenticated as jest.Mock).mockReturnValue(true);
-    (getApplications as jest.Mock).mockRejectedValue(new Error('Network error'));
-
-    render(<DashboardPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText(/failed to load applications/i)).toBeInTheDocument();
-    });
-  });
-
-  it('renders logout button', async () => {
-    (isAuthenticated as jest.Mock).mockReturnValue(true);
-    (getApplications as jest.Mock).mockResolvedValue([]);
-
-    render(<DashboardPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText(/logout/i)).toBeInTheDocument();
-    });
+    await waitFor(() =>
+      expect(screen.getByText(/failed to load dashboard data/i)).toBeInTheDocument(),
+    );
   });
 });

--- a/frontend/app/(app)/dashboard/page.tsx
+++ b/frontend/app/(app)/dashboard/page.tsx
@@ -2,16 +2,17 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { getApplications, getStats } from '@/lib/applicationService';
-import { isAuthenticated, removeToken, removeUsername } from '@/lib/auth';
-import { Application, StatsResponse } from '@/types';
+import { getStats } from '@/lib/applicationService';
+import { isAuthenticated } from '@/lib/auth';
+import { StatsResponse } from '@/types';
+import Spinner from '@/components/ui/Spinner';
 import StatsBar from '@/components/dashboard/StatsBar';
 import ApplicationsChart from '@/components/dashboard/ApplicationsChart';
 import StatusChart from '@/components/dashboard/StatusChart';
+import ApplicationsTable from '@/components/applications/ApplicationsTable';
 
 export default function DashboardPage() {
   const router = useRouter();
-  const [applications, setApplications] = useState<Application[]>([]);
   const [stats, setStats] = useState<StatsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -24,11 +25,10 @@ export default function DashboardPage() {
 
     const fetchData = async () => {
       try {
-        const [data, statsData] = await Promise.all([getApplications(), getStats()]);
-        setApplications(data);
+        const statsData = await getStats();
         setStats(statsData);
       } catch {
-        setError('Failed to load applications');
+        setError('Failed to load dashboard data');
       } finally {
         setLoading(false);
       }
@@ -37,119 +37,33 @@ export default function DashboardPage() {
     fetchData();
   }, [router]);
 
-  const handleLogout = () => {
-    removeToken();
-    removeUsername();
-    router.push('/login');
-  };
-
-  const getStatusColor = (status: string) => {
-    const colors: Record<string, string> = {
-      APPLIED: 'bg-blue-100 text-blue-800',
-      SCREENING: 'bg-yellow-100 text-yellow-800',
-      INTERVIEWING: 'bg-purple-100 text-purple-800',
-      OFFER: 'bg-green-100 text-green-800',
-      REJECTED: 'bg-red-100 text-red-800',
-      WITHDRAWN: 'bg-gray-100 text-gray-800',
-    };
-    return colors[status] || 'bg-gray-100 text-gray-800';
-  };
-
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-100">
-        <p className="text-gray-600">Loading...</p>
+      <div className="flex items-center justify-center py-16">
+        <Spinner size="lg" />
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-100">
-      <header className="bg-white shadow">
-        <div className="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
-          <h1 className="text-2xl font-bold text-gray-900">Job Applications</h1>
-          <button
-            onClick={handleLogout}
-            className="text-gray-600 hover:text-gray-900"
-          >
-            Logout
-          </button>
+    <div className="max-w-7xl mx-auto px-4 py-8 space-y-6">
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-400">
+          {error}
         </div>
-      </header>
+      )}
 
-      <main className="max-w-7xl mx-auto px-4 py-8 space-y-6">
-        {error && (
-          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
-            {error}
+      {stats && (
+        <>
+          <StatsBar stats={stats} />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <ApplicationsChart data={stats.monthlyApplications} />
+            <StatusChart statusBreakdown={stats.statusBreakdown} />
           </div>
-        )}
+        </>
+      )}
 
-        {stats && (
-          <>
-            <StatsBar stats={stats} />
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <ApplicationsChart data={stats.monthlyApplications} />
-              <StatusChart statusBreakdown={stats.statusBreakdown} />
-            </div>
-          </>
-        )}
-
-        {applications.length === 0 ? (
-          <div className="bg-white rounded-lg shadow p-8 text-center">
-            <p className="text-gray-600 mb-4">No applications yet</p>
-            <button className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">
-              Add Your First Application
-            </button>
-          </div>
-        ) : (
-          <div className="bg-white rounded-lg shadow overflow-hidden">
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Company
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Role
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Status
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Applied Date
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Location
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
-                {applications.map((app) => (
-                  <tr key={app.id} className="hover:bg-gray-50">
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div className="font-medium text-gray-900">{app.companyName}</div>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-gray-600">
-                      {app.jobRole}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <span className={`px-2 py-1 text-xs font-medium rounded-full ${getStatusColor(app.status)}`}>
-                        {app.status}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-gray-600">
-                      {app.appliedDate}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-gray-600">
-                      {app.location}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </main>
+      <ApplicationsTable />
     </div>
   );
 }

--- a/frontend/components/applications/ApplicationsTable.tsx
+++ b/frontend/components/applications/ApplicationsTable.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { getApplications } from '@/lib/applicationService';
+import { Application, JobType, PagedResponse } from '@/types';
+import { StatusBadge } from '@/components/ui/Badge';
+import Pagination from '@/components/ui/Pagination';
+import Spinner from '@/components/ui/Spinner';
+
+const PAGE_SIZE = 20;
+
+const JOB_TYPE_LABELS: Record<JobType, string> = {
+    FULL_TIME: 'Full-time',
+    PART_TIME: 'Part-time',
+    CONTRACT: 'Contract',
+    INTERNSHIP: 'Internship',
+};
+
+const thCls =
+    'px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)]';
+const tdCls = 'px-4 py-3 text-sm text-[var(--foreground)] whitespace-nowrap';
+
+export default function ApplicationsTable() {
+    const [page, setPage] = useState(0);
+    const [data, setData] = useState<PagedResponse<Application> | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+
+    const fetchPage = useCallback(async (p: number) => {
+        setLoading(true);
+        setError('');
+        try {
+            const result = await getApplications(p, PAGE_SIZE, 'appliedDate,desc');
+            setData(result);
+        } catch {
+            setError('Failed to load applications. Please try again.');
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchPage(page);
+    }, [page, fetchPage]);
+
+    const handlePageChange = useCallback((p: number) => {
+        setPage(p);
+    }, []);
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center py-16">
+                <Spinner size="lg" />
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-8 text-center">
+                <p className="text-sm text-[var(--muted-foreground)] mb-3">{error}</p>
+                <button
+                    onClick={() => fetchPage(page)}
+                    className="text-sm font-medium text-[var(--primary)] hover:underline"
+                >
+                    Retry
+                </button>
+            </div>
+        );
+    }
+
+    if (!data || data.totalElements === 0) {
+        return (
+            <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-8 text-center">
+                <p className="text-[var(--muted-foreground)]">No applications yet.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] overflow-hidden">
+            <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-[var(--border)]">
+                    <thead className="bg-[var(--muted)]/40">
+                        <tr>
+                            <th className={thCls}>Company</th>
+                            <th className={thCls}>Role</th>
+                            <th className={thCls}>Status</th>
+                            <th className={thCls}>Applied Date</th>
+                            <th className={thCls}>Location</th>
+                            <th className={thCls}>Job Type</th>
+                            <th className={thCls}>Credentials</th>
+                            <th className={thCls}>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-[var(--border)]">
+                        {data.content.map((app) => (
+                            <tr
+                                key={app.id}
+                                className="hover:bg-[var(--muted)]/30 transition-colors"
+                            >
+                                <td className={`${tdCls} font-medium`}>{app.companyName}</td>
+                                <td className={tdCls}>{app.jobRole}</td>
+                                <td className={tdCls}>
+                                    <StatusBadge status={app.status} />
+                                </td>
+                                <td className={tdCls}>{app.appliedDate}</td>
+                                <td className={`${tdCls} text-[var(--muted-foreground)]`}>
+                                    {app.location}
+                                </td>
+                                <td className={`${tdCls} text-[var(--muted-foreground)]`}>
+                                    {JOB_TYPE_LABELS[app.jobType]}
+                                </td>
+                                <td className={`${tdCls} font-mono text-[var(--muted-foreground)]`}>
+                                    {app.username || app.password ? '••••••••' : '—'}
+                                </td>
+                                <td className={tdCls}>—</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+
+            {data.totalPages > 1 && (
+                <div className="px-4 py-3 border-t border-[var(--border)]">
+                    <Pagination
+                        page={data.number}
+                        totalPages={data.totalPages}
+                        totalElements={data.totalElements}
+                        pageSize={data.size}
+                        onPageChange={handlePageChange}
+                    />
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/lib/applicationService.ts
+++ b/frontend/lib/applicationService.ts
@@ -1,9 +1,15 @@
 import api from './api';
-import { Application, StatsResponse } from '@/types';
+import { Application, PagedResponse, StatsResponse } from '@/types';
 
-export const getApplications = async (): Promise<Application[]> => {
-  const response = await api.get<{ content: Application[] }>('/applications');
-  return response.data.content;
+export const getApplications = async (
+  page = 0,
+  size = 20,
+  sort = 'appliedDate,desc',
+): Promise<PagedResponse<Application>> => {
+  const response = await api.get<PagedResponse<Application>>('/applications', {
+    params: { page, size, sort },
+  });
+  return response.data;
 };
 
 export const getApplication = async (id: string): Promise<Application> => {

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -63,6 +63,17 @@ export interface UpdateProfileRequest {
     themePreference?: ThemePreference;
 }
 
+// Mirrors Spring Page<T> response from paginated endpoints
+export interface PagedResponse<T> {
+    content: T[];
+    totalPages: number;
+    totalElements: number;
+    number: number;
+    size: number;
+    first: boolean;
+    last: boolean;
+}
+
 // Mirrors MonthlyCount DTO from GET /applications/stats
 export interface MonthlyCount {
     month: string;


### PR DESCRIPTION
## Summary
- Add `PagedResponse<T>` type mirroring Spring `Page<T>` response
- Update `getApplications()` to accept `page/size/sort` params and return `PagedResponse<Application>`
- Add `ApplicationsTable` component with loading spinner, error+retry, empty state, 8-column table (Company, Role, Status, Applied Date, Location, Job Type, Credentials, Actions), and Pagination
- Replace dashboard inline table + custom header with `<ApplicationsTable />`; dashboard now fetches only stats
- 13 new tests for `ApplicationsTable`; updated `dashboard.test.tsx` to match new structure

## Test plan
- [x] 179 tests passing, lint clean
- [x] `ApplicationsTable` renders spinner on load, rows after fetch, empty state, error+retry, pagination controls
- [x] Dashboard page no longer calls `getApplications` directly — table is self-contained

🤖 Generated with [Claude Code](https://claude.com/claude-code)