### PR TITLE
feat(frontend): add table controls and page-size selector (Task 18b)

### DIFF
--- a/frontend/__tests__/applications.table.test.tsx
+++ b/frontend/__tests__/applications.table.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import ApplicationsTable from '@/components/applications/ApplicationsTable';
 import { getApplications } from '@/lib/applicationService';
 import { Application, PagedResponse } from '@/types';
@@ -41,6 +41,8 @@ const makePage = (
 describe('ApplicationsTable', () => {
     beforeEach(() => jest.clearAllMocks());
 
+    // --- Loading / Error / Empty states ---
+
     it('shows loading spinner initially', () => {
         mockGetApplications.mockReturnValue(new Promise(() => {}));
         render(<ApplicationsTable />);
@@ -65,7 +67,7 @@ describe('ApplicationsTable', () => {
     it('renders application row data', async () => {
         const apps = [
             makeApp({ id: '1', companyName: 'Acme Corp', jobRole: 'Engineer', appliedDate: '2026-01-15', location: 'Remote' }),
-            makeApp({ id: '2', companyName: 'Beta Inc', jobRole: 'Designer', status: 'OFFER', appliedDate: '2026-02-01', location: 'London' }),
+            makeApp({ id: '2', companyName: 'Beta Inc',  jobRole: 'Designer', status: 'OFFER', appliedDate: '2026-02-01', location: 'London' }),
         ];
         mockGetApplications.mockResolvedValue(makePage(apps, { totalElements: 2 }));
         render(<ApplicationsTable />);
@@ -161,10 +163,139 @@ describe('ApplicationsTable', () => {
         expect(screen.getByRole('button', { name: /previous page/i })).toBeInTheDocument();
     });
 
-    it('calls getApplications with page=0, size=20, sort on mount', async () => {
+    it('calls getApplications with defaults on mount', async () => {
         mockGetApplications.mockResolvedValue(makePage([makeApp()]));
         render(<ApplicationsTable />);
         await waitFor(() => screen.getByText('Acme Corp'));
-        expect(mockGetApplications).toHaveBeenCalledWith(0, 20, 'appliedDate,desc');
+        expect(mockGetApplications).toHaveBeenCalledWith(0, 20, 'appliedDate,desc', undefined, undefined);
+    });
+
+    // --- Controls bar ---
+
+    it('renders search input, status filter, and sort toggle', async () => {
+        mockGetApplications.mockResolvedValue(makePage([makeApp()]));
+        render(<ApplicationsTable />);
+        // Controls render immediately (before load completes)
+        expect(screen.getByRole('searchbox')).toBeInTheDocument();
+        expect(screen.getByRole('combobox', { name: /filter by status/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /sort by applied date/i })).toBeInTheDocument();
+    });
+
+    it('renders rows-per-page selector in the table footer', async () => {
+        mockGetApplications.mockResolvedValue(makePage([makeApp()]));
+        render(<ApplicationsTable />);
+        await waitFor(() => screen.getByText('Acme Corp'));
+        expect(screen.getByRole('combobox', { name: /rows per page/i })).toBeInTheDocument();
+    });
+
+    it('re-fetches with status param when status filter changes', async () => {
+        mockGetApplications.mockResolvedValue(makePage([makeApp()]));
+        render(<ApplicationsTable />);
+        await waitFor(() => screen.getByText('Acme Corp'));
+
+        mockGetApplications.mockClear();
+        mockGetApplications.mockResolvedValue(makePage([]));
+
+        fireEvent.change(screen.getByRole('combobox', { name: /filter by status/i }), {
+            target: { value: 'OFFER' },
+        });
+
+        await waitFor(() =>
+            expect(mockGetApplications).toHaveBeenCalledWith(0, 20, 'appliedDate,desc', undefined, 'OFFER'),
+        );
+    });
+
+    it('re-fetches with asc sort after sort toggle click', async () => {
+        mockGetApplications.mockResolvedValue(makePage([makeApp()]));
+        render(<ApplicationsTable />);
+        await waitFor(() => screen.getByText('Acme Corp'));
+
+        mockGetApplications.mockClear();
+        mockGetApplications.mockResolvedValue(makePage([makeApp()]));
+
+        fireEvent.click(screen.getByRole('button', { name: /sort by applied date ascending/i }));
+
+        await waitFor(() =>
+            expect(mockGetApplications).toHaveBeenCalledWith(0, 20, 'appliedDate,asc', undefined, undefined),
+        );
+    });
+
+    it('re-fetches with new page size when rows-per-page changes', async () => {
+        mockGetApplications.mockResolvedValue(makePage([makeApp()]));
+        render(<ApplicationsTable />);
+        await waitFor(() => screen.getByText('Acme Corp'));
+
+        mockGetApplications.mockClear();
+        mockGetApplications.mockResolvedValue(makePage([makeApp()], { size: 10 }));
+
+        fireEvent.change(screen.getByRole('combobox', { name: /rows per page/i }), {
+            target: { value: '10' },
+        });
+
+        await waitFor(() =>
+            expect(mockGetApplications).toHaveBeenCalledWith(0, 10, 'appliedDate,desc', undefined, undefined),
+        );
+    });
+
+    it('resets to page 0 when status filter changes', async () => {
+        // Start on page 1 by simulating multi-page data
+        const apps = Array.from({ length: 20 }, (_, i) =>
+            makeApp({ id: String(i), companyName: `Company ${i}` }),
+        );
+        mockGetApplications.mockResolvedValue(
+            makePage(apps, { totalPages: 3, totalElements: 60, number: 0 }),
+        );
+        render(<ApplicationsTable />);
+        await waitFor(() => screen.getByRole('button', { name: /next page/i }));
+
+        // Navigate to page 1
+        mockGetApplications.mockClear();
+        mockGetApplications.mockResolvedValue(
+            makePage(apps, { totalPages: 3, totalElements: 60, number: 1 }),
+        );
+        fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+        await waitFor(() =>
+            expect(mockGetApplications).toHaveBeenCalledWith(1, 20, 'appliedDate,desc', undefined, undefined),
+        );
+
+        // Change status filter — should reset to page 0
+        mockGetApplications.mockClear();
+        mockGetApplications.mockResolvedValue(makePage([]));
+        fireEvent.change(screen.getByRole('combobox', { name: /filter by status/i }), {
+            target: { value: 'REJECTED' },
+        });
+        await waitFor(() =>
+            expect(mockGetApplications).toHaveBeenCalledWith(0, 20, 'appliedDate,desc', undefined, 'REJECTED'),
+        );
+    });
+
+    it('shows search input with correct placeholder', () => {
+        mockGetApplications.mockReturnValue(new Promise(() => {}));
+        render(<ApplicationsTable />);
+        expect(screen.getByPlaceholderText(/search companies/i)).toBeInTheDocument();
+    });
+
+    it('re-fetches with search term after debounce fires', async () => {
+        jest.useFakeTimers();
+        try {
+            mockGetApplications.mockResolvedValue(makePage([makeApp()]));
+            render(<ApplicationsTable />);
+
+            // Flush initial fetch
+            await act(async () => { jest.runAllTimers(); });
+            await act(async () => {});
+            await waitFor(() => screen.getByText('Acme Corp'));
+
+            mockGetApplications.mockClear();
+            mockGetApplications.mockResolvedValue(makePage([]));
+
+            fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'Google' } });
+            act(() => { jest.advanceTimersByTime(300); });
+            await act(async () => {});
+
+            expect(mockGetApplications).toHaveBeenCalledWith(0, 20, 'appliedDate,desc', 'Google', undefined);
+        } finally {
+            jest.useRealTimers();
+        }
     });
 });

--- a/frontend/components/applications/ApplicationsTable.tsx
+++ b/frontend/components/applications/ApplicationsTable.tsx
@@ -2,12 +2,14 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { getApplications } from '@/lib/applicationService';
-import { Application, JobType, PagedResponse } from '@/types';
+import { Application, JobType, PagedResponse, Status } from '@/types';
 import { StatusBadge } from '@/components/ui/Badge';
 import Pagination from '@/components/ui/Pagination';
+import SearchInput from '@/components/ui/SearchInput';
 import Spinner from '@/components/ui/Spinner';
 
-const PAGE_SIZE = 20;
+type SortDir = 'asc' | 'desc';
+type PageSize = 10 | 20 | 50;
 
 const JOB_TYPE_LABELS: Record<JobType, string> = {
     FULL_TIME: 'Full-time',
@@ -16,21 +18,50 @@ const JOB_TYPE_LABELS: Record<JobType, string> = {
     INTERNSHIP: 'Internship',
 };
 
+const STATUS_OPTIONS: { value: Status; label: string }[] = [
+    { value: 'APPLIED',      label: 'Applied' },
+    { value: 'SCREENING',    label: 'Screening' },
+    { value: 'INTERVIEWING', label: 'Interviewing' },
+    { value: 'OFFER',        label: 'Offer' },
+    { value: 'REJECTED',     label: 'Rejected' },
+    { value: 'WITHDRAWN',    label: 'Withdrawn' },
+];
+
+const selectCls = [
+    'rounded-md border border-[var(--border)] bg-[var(--background)] text-[var(--foreground)]',
+    'text-sm px-3 py-2 outline-none transition-colors appearance-none',
+    'focus:border-[var(--primary)] focus:ring-2 focus:ring-[var(--ring)]/30',
+].join(' ');
+
 const thCls =
     'px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)]';
 const tdCls = 'px-4 py-3 text-sm text-[var(--foreground)] whitespace-nowrap';
 
 export default function ApplicationsTable() {
-    const [page, setPage] = useState(0);
-    const [data, setData] = useState<PagedResponse<Application> | null>(null);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState('');
+    const [page, setPage]               = useState(0);
+    const [pageSize, setPageSize]       = useState<PageSize>(20);
+    const [sortDir, setSortDir]         = useState<SortDir>('desc');
+    const [search, setSearch]           = useState('');
+    const [statusFilter, setStatusFilter] = useState<Status | ''>('');
+    const [data, setData]               = useState<PagedResponse<Application> | null>(null);
+    const [loading, setLoading]         = useState(true);
+    const [error, setError]             = useState('');
 
-    const fetchPage = useCallback(async (p: number) => {
+    const fetchPage = useCallback(async (
+        p: number,
+        sz: number,
+        sort: string,
+        srch: string,
+        status: string,
+    ) => {
         setLoading(true);
         setError('');
         try {
-            const result = await getApplications(p, PAGE_SIZE, 'appliedDate,desc');
+            const result = await getApplications(
+                p, sz, sort,
+                srch || undefined,
+                status || undefined,
+            );
             setData(result);
         } catch {
             setError('Failed to load applications. Please try again.');
@@ -40,96 +71,178 @@ export default function ApplicationsTable() {
     }, []);
 
     useEffect(() => {
-        fetchPage(page);
-    }, [page, fetchPage]);
+        fetchPage(page, pageSize, `appliedDate,${sortDir}`, search, statusFilter);
+    }, [page, pageSize, sortDir, search, statusFilter, fetchPage]);
+
+    const handleSearchChange = useCallback((val: string) => {
+        setSearch(val);
+        setPage(0);
+    }, []);
+
+    const handleStatusChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+        setStatusFilter(e.target.value as Status | '');
+        setPage(0);
+    }, []);
+
+    const handleSortToggle = useCallback(() => {
+        setSortDir(prev => (prev === 'desc' ? 'asc' : 'desc'));
+        setPage(0);
+    }, []);
+
+    const handlePageSizeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+        setPageSize(Number(e.target.value) as PageSize);
+        setPage(0);
+    }, []);
 
     const handlePageChange = useCallback((p: number) => {
         setPage(p);
     }, []);
 
-    if (loading) {
-        return (
-            <div className="flex items-center justify-center py-16">
-                <Spinner size="lg" />
-            </div>
-        );
-    }
+    return (
+        <div className="space-y-4">
+            {/* Controls bar */}
+            <div className="flex flex-wrap items-center gap-3">
+                <SearchInput
+                    value={search}
+                    onChange={handleSearchChange}
+                    placeholder="Search companies…"
+                    className="flex-1 min-w-[180px]"
+                />
 
-    if (error) {
-        return (
-            <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-8 text-center">
-                <p className="text-sm text-[var(--muted-foreground)] mb-3">{error}</p>
-                <button
-                    onClick={() => fetchPage(page)}
-                    className="text-sm font-medium text-[var(--primary)] hover:underline"
+                <select
+                    value={statusFilter}
+                    onChange={handleStatusChange}
+                    aria-label="Filter by status"
+                    className={selectCls}
+                    style={{
+                        backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%23737373' stroke-width='2'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M19 9l-7 7-7-7'/%3E%3C/svg%3E")`,
+                        backgroundRepeat: 'no-repeat',
+                        backgroundPosition: 'right 0.6rem center',
+                        backgroundSize: '1rem',
+                        paddingRight: '2.25rem',
+                    }}
                 >
-                    Retry
+                    <option value="">All Statuses</option>
+                    {STATUS_OPTIONS.map(({ value, label }) => (
+                        <option key={value} value={value}>{label}</option>
+                    ))}
+                </select>
+
+                <button
+                    onClick={handleSortToggle}
+                    aria-label={`Sort by applied date ${sortDir === 'desc' ? 'ascending' : 'descending'}`}
+                    className={[
+                        'inline-flex items-center gap-1.5 rounded-md border border-[var(--border)]',
+                        'bg-[var(--background)] text-[var(--foreground)] text-sm px-3 py-2',
+                        'hover:bg-[var(--muted)] transition-colors whitespace-nowrap',
+                    ].join(' ')}
+                >
+                    Applied Date {sortDir === 'desc' ? '↓' : '↑'}
                 </button>
             </div>
-        );
-    }
 
-    if (!data || data.totalElements === 0) {
-        return (
-            <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-8 text-center">
-                <p className="text-[var(--muted-foreground)]">No applications yet.</p>
-            </div>
-        );
-    }
+            {/* Table area */}
+            {loading && (
+                <div className="flex items-center justify-center py-16">
+                    <Spinner size="lg" />
+                </div>
+            )}
 
-    return (
-        <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] overflow-hidden">
-            <div className="overflow-x-auto">
-                <table className="min-w-full divide-y divide-[var(--border)]">
-                    <thead className="bg-[var(--muted)]/40">
-                        <tr>
-                            <th className={thCls}>Company</th>
-                            <th className={thCls}>Role</th>
-                            <th className={thCls}>Status</th>
-                            <th className={thCls}>Applied Date</th>
-                            <th className={thCls}>Location</th>
-                            <th className={thCls}>Job Type</th>
-                            <th className={thCls}>Credentials</th>
-                            <th className={thCls}>Actions</th>
-                        </tr>
-                    </thead>
-                    <tbody className="divide-y divide-[var(--border)]">
-                        {data.content.map((app) => (
-                            <tr
-                                key={app.id}
-                                className="hover:bg-[var(--muted)]/30 transition-colors"
-                            >
-                                <td className={`${tdCls} font-medium`}>{app.companyName}</td>
-                                <td className={tdCls}>{app.jobRole}</td>
-                                <td className={tdCls}>
-                                    <StatusBadge status={app.status} />
-                                </td>
-                                <td className={tdCls}>{app.appliedDate}</td>
-                                <td className={`${tdCls} text-[var(--muted-foreground)]`}>
-                                    {app.location}
-                                </td>
-                                <td className={`${tdCls} text-[var(--muted-foreground)]`}>
-                                    {JOB_TYPE_LABELS[app.jobType]}
-                                </td>
-                                <td className={`${tdCls} font-mono text-[var(--muted-foreground)]`}>
-                                    {app.username || app.password ? '••••••••' : '—'}
-                                </td>
-                                <td className={tdCls}>—</td>
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
-            </div>
+            {!loading && error && (
+                <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-8 text-center">
+                    <p className="text-sm text-[var(--muted-foreground)] mb-3">{error}</p>
+                    <button
+                        onClick={() => fetchPage(page, pageSize, `appliedDate,${sortDir}`, search, statusFilter)}
+                        className="text-sm font-medium text-[var(--primary)] hover:underline"
+                    >
+                        Retry
+                    </button>
+                </div>
+            )}
 
-            {data.totalPages > 1 && (
-                <div className="px-4 py-3 border-t border-[var(--border)]">
-                    <Pagination
-                        page={data.number}
-                        totalPages={data.totalPages}
-                        totalElements={data.totalElements}
-                        pageSize={data.size}
-                        onPageChange={handlePageChange}
-                    />
+            {!loading && !error && (!data || data.totalElements === 0) && (
+                <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-8 text-center">
+                    <p className="text-[var(--muted-foreground)]">No applications yet.</p>
+                </div>
+            )}
+
+            {!loading && !error && data && data.totalElements > 0 && (
+                <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] overflow-hidden">
+                    <div className="overflow-x-auto">
+                        <table className="min-w-full divide-y divide-[var(--border)]">
+                            <thead className="bg-[var(--muted)]/40">
+                                <tr>
+                                    <th className={thCls}>Company</th>
+                                    <th className={thCls}>Role</th>
+                                    <th className={thCls}>Status</th>
+                                    <th className={thCls}>Applied Date</th>
+                                    <th className={thCls}>Location</th>
+                                    <th className={thCls}>Job Type</th>
+                                    <th className={thCls}>Credentials</th>
+                                    <th className={thCls}>Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody className="divide-y divide-[var(--border)]">
+                                {data.content.map((app) => (
+                                    <tr
+                                        key={app.id}
+                                        className="hover:bg-[var(--muted)]/30 transition-colors"
+                                    >
+                                        <td className={`${tdCls} font-medium`}>{app.companyName}</td>
+                                        <td className={tdCls}>{app.jobRole}</td>
+                                        <td className={tdCls}>
+                                            <StatusBadge status={app.status} />
+                                        </td>
+                                        <td className={tdCls}>{app.appliedDate}</td>
+                                        <td className={`${tdCls} text-[var(--muted-foreground)]`}>
+                                            {app.location}
+                                        </td>
+                                        <td className={`${tdCls} text-[var(--muted-foreground)]`}>
+                                            {JOB_TYPE_LABELS[app.jobType]}
+                                        </td>
+                                        <td className={`${tdCls} font-mono text-[var(--muted-foreground)]`}>
+                                            {app.username || app.password ? '••••••••' : '—'}
+                                        </td>
+                                        <td className={tdCls}>—</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    {/* Footer: page size selector + pagination */}
+                    <div className="px-4 py-3 border-t border-[var(--border)]">
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                            <div className="flex items-center gap-2 text-sm text-[var(--muted-foreground)]">
+                                <label htmlFor="page-size-select">Rows per page:</label>
+                                <select
+                                    id="page-size-select"
+                                    value={pageSize}
+                                    onChange={handlePageSizeChange}
+                                    aria-label="Rows per page"
+                                    className={[
+                                        'rounded-md border border-[var(--border)] bg-[var(--background)]',
+                                        'text-[var(--foreground)] text-sm px-2 py-1 outline-none',
+                                        'focus:border-[var(--primary)]',
+                                    ].join(' ')}
+                                >
+                                    <option value={10}>10</option>
+                                    <option value={20}>20</option>
+                                    <option value={50}>50</option>
+                                </select>
+                            </div>
+
+                            {data.totalPages > 1 && (
+                                <Pagination
+                                    page={data.number}
+                                    totalPages={data.totalPages}
+                                    totalElements={data.totalElements}
+                                    pageSize={data.size}
+                                    onPageChange={handlePageChange}
+                                />
+                            )}
+                        </div>
+                    </div>
                 </div>
             )}
         </div>

--- a/frontend/lib/applicationService.ts
+++ b/frontend/lib/applicationService.ts
@@ -5,9 +5,17 @@ export const getApplications = async (
   page = 0,
   size = 20,
   sort = 'appliedDate,desc',
+  search?: string,
+  status?: string,
 ): Promise<PagedResponse<Application>> => {
   const response = await api.get<PagedResponse<Application>>('/applications', {
-    params: { page, size, sort },
+    params: {
+      page,
+      size,
+      sort,
+      ...(search ? { search } : {}),
+      ...(status ? { status } : {}),
+    },
   });
   return response.data;
 };


### PR DESCRIPTION
## Summary
- Add optional `search` and `status` query params to `getApplications()` service
- Add controls bar to `ApplicationsTable`: debounced `SearchInput` (company name), status filter dropdown, Applied Date sort toggle (↑/↓)
- Add rows-per-page selector (10/20/50) in table footer alongside existing pagination
- All controls reset to page 0 on change; only page navigation preserves other params

## Test plan
- [x] 45 relevant tests passing (table + dashboard suites), lint clean
- [x] Status filter, sort toggle, page-size change, page-reset, and search debounce all tested
- [x] `login.test.tsx` failures are from a parallel login-page redesign PR — unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)