### PR TITLE
feat(frontend): polish auth pages and fix tests

### DIFF
--- a/frontend/__tests__/login.test.tsx
+++ b/frontend/__tests__/login.test.tsx
@@ -49,7 +49,7 @@ describe('LoginPage', () => {
 
     expect(screen.getByLabelText(/email or username/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/password/i, { selector: 'input' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /login/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
     expect(screen.getByText(/don't have an account/i)).toBeInTheDocument();
   });
 
@@ -68,9 +68,9 @@ describe('LoginPage', () => {
     fireEvent.change(screen.getByLabelText(/password/i, { selector: 'input' }), {
       target: { value: 'password123' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
 
-    expect(await screen.findByText(/logging in/i)).toBeInTheDocument();
+    expect(await screen.findByText(/signing in/i)).toBeInTheDocument();
   });
 
   it('redirects to dashboard on successful login', async () => {
@@ -91,7 +91,7 @@ describe('LoginPage', () => {
     fireEvent.change(screen.getByLabelText(/password/i, { selector: 'input' }), {
       target: { value: 'password123' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
 
     await waitFor(() => {
       expect(login).toHaveBeenCalledWith({
@@ -120,7 +120,7 @@ describe('LoginPage', () => {
     fireEvent.change(screen.getByLabelText(/password/i, { selector: 'input' }), {
       target: { value: 'wrongpassword' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
 
     expect(await screen.findByText(/invalid email\/username or password/i)).toBeInTheDocument();
   });
@@ -140,7 +140,7 @@ describe('LoginPage', () => {
     fireEvent.change(screen.getByLabelText(/password/i, { selector: 'input' }), {
       target: { value: 'password123' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
 
     expect(await screen.findByText(/something went wrong/i)).toBeInTheDocument();
   });
@@ -152,7 +152,7 @@ describe('LoginPage', () => {
       </ThemeProvider>
     );
 
-    const registerLink = screen.getByRole('link', { name: /register/i });
+    const registerLink = screen.getByRole('link', { name: /create one/i });
     expect(registerLink).toHaveAttribute('href', '/register');
   });
 });

--- a/frontend/__tests__/register.test.tsx
+++ b/frontend/__tests__/register.test.tsx
@@ -49,7 +49,7 @@ describe('RegisterPage', () => {
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/password/i, { selector: 'input' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /register/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create account/i })).toBeInTheDocument();
     expect(screen.getByText(/already have an account/i)).toBeInTheDocument();
   });
 
@@ -71,7 +71,7 @@ describe('RegisterPage', () => {
     fireEvent.change(screen.getByLabelText(/password/i, { selector: 'input' }), {
       target: { value: 'password123' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /register/i }));
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
 
     expect(await screen.findByText(/creating account/i)).toBeInTheDocument();
   });
@@ -97,7 +97,7 @@ describe('RegisterPage', () => {
     fireEvent.change(screen.getByLabelText(/password/i, { selector: 'input' }), {
       target: { value: 'password123' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /register/i }));
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
 
     await waitFor(() => {
       expect(register).toHaveBeenCalledWith({
@@ -130,7 +130,7 @@ describe('RegisterPage', () => {
     fireEvent.change(screen.getByLabelText(/password/i, { selector: 'input' }), {
       target: { value: 'password123' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /register/i }));
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
 
     expect(await screen.findByText(/already registered/i)).toBeInTheDocument();
   });
@@ -153,7 +153,7 @@ describe('RegisterPage', () => {
     fireEvent.change(screen.getByLabelText(/password/i, { selector: 'input' }), {
       target: { value: 'password123' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /register/i }));
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
 
     expect(await screen.findByText(/something went wrong/i)).toBeInTheDocument();
   });
@@ -165,7 +165,7 @@ describe('RegisterPage', () => {
       </ThemeProvider>
     );
 
-    const loginLink = screen.getByRole('link', { name: /login/i });
+    const loginLink = screen.getByRole('link', { name: /sign in/i });
     expect(loginLink).toHaveAttribute('href', '/login');
   });
 });

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -39,8 +39,14 @@ function LoginContent() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[var(--background)] relative">
-      <div className="absolute top-4 right-4">
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[var(--background)]">
+      {/* Decorative background gradient for depth */}
+      <div
+        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-[var(--primary)]/5 via-transparent to-transparent"
+        aria-hidden="true"
+      />
+
+      <div className="absolute right-4 top-4 z-10">
         <ThemeToggle />
       </div>
 
@@ -57,18 +63,58 @@ function LoginContent() {
         </div>
       </Modal>
 
-      <div className="w-full max-w-md rounded-xl border border-[var(--border)] bg-[var(--card)] p-8 shadow-md">
-        <h1 className="mb-6 text-center text-2xl font-bold text-[var(--card-foreground)]">
-          Login
-        </h1>
+      {/* Auth card */}
+      <div className="relative mx-4 w-full max-w-md rounded-2xl border border-[var(--border)] bg-[var(--card)] p-8 shadow-xl shadow-black/5 dark:shadow-black/30">
 
+        {/* Brand mark */}
+        <div className="mb-8 flex flex-col items-center gap-4">
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-[var(--primary)] text-[var(--primary-foreground)] shadow-sm">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="h-6 w-6"
+              aria-hidden="true"
+            >
+              <rect x="2" y="7" width="20" height="14" rx="2" ry="2" />
+              <path d="M16 7V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v2" />
+            </svg>
+          </div>
+          <div className="text-center">
+            <h1 className="text-2xl font-bold tracking-tight text-[var(--card-foreground)]">
+              Welcome back
+            </h1>
+            <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+              Sign in to your JobTracker account
+            </p>
+          </div>
+        </div>
+
+        {/* Error banner */}
         {error && (
-          <div className="mb-4 rounded-md border border-[var(--destructive)]/30 bg-[var(--destructive)]/10 px-4 py-3 text-sm text-[var(--destructive)]">
+          <div className="mb-5 flex items-start gap-3 rounded-lg border border-[var(--destructive)]/30 bg-[var(--destructive)]/10 px-4 py-3 text-sm text-[var(--destructive)]">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="mt-0.5 h-4 w-4 shrink-0"
+              aria-hidden="true"
+            >
+              <path
+                fillRule="evenodd"
+                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0110 5zm0 10a1 1 0 100-2 1 1 0 000 2z"
+                clipRule="evenodd"
+              />
+            </svg>
             {error}
           </div>
         )}
 
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-5">
           <Input
             label="Email or Username"
             type="text"
@@ -85,15 +131,25 @@ function LoginContent() {
             autoComplete="current-password"
             required
           />
-          <Button type="submit" loading={loading} size="lg" className="mt-2 w-full">
-            {loading ? 'Logging in...' : 'Login'}
+          <Button type="submit" loading={loading} size="lg" className="mt-1 w-full">
+            {loading ? 'Signing in...' : 'Sign in'}
           </Button>
         </form>
 
-        <p className="mt-4 text-center text-sm text-[var(--muted-foreground)]">
+        {/* Divider */}
+        <div className="my-6 flex items-center gap-3" aria-hidden="true">
+          <div className="h-px flex-1 bg-[var(--border)]" />
+          <span className="text-xs text-[var(--muted-foreground)]">or</span>
+          <div className="h-px flex-1 bg-[var(--border)]" />
+        </div>
+
+        <p className="text-center text-sm text-[var(--muted-foreground)]">
           Don&apos;t have an account?{' '}
-          <Link href="/register" className="font-medium text-[var(--primary)] hover:underline">
-            Register
+          <Link
+            href="/register"
+            className="font-semibold text-[var(--primary)] transition-opacity duration-150 hover:opacity-75 focus-visible:rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+          >
+            Create one
           </Link>
         </p>
       </div>

--- a/frontend/app/(auth)/register/page.tsx
+++ b/frontend/app/(auth)/register/page.tsx
@@ -50,23 +50,69 @@ export default function RegisterPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[var(--background)] relative">
-      <div className="absolute top-4 right-4">
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[var(--background)]">
+      {/* Decorative background gradient for depth */}
+      <div
+        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-[var(--primary)]/5 via-transparent to-transparent"
+        aria-hidden="true"
+      />
+
+      <div className="absolute right-4 top-4 z-10">
         <ThemeToggle />
       </div>
 
-      <div className="w-full max-w-md rounded-xl border border-[var(--border)] bg-[var(--card)] p-8 shadow-md">
-        <h1 className="mb-6 text-center text-2xl font-bold text-[var(--card-foreground)]">
-          Register
-        </h1>
+      {/* Auth card */}
+      <div className="relative mx-4 w-full max-w-md rounded-2xl border border-[var(--border)] bg-[var(--card)] p-8 shadow-xl shadow-black/5 dark:shadow-black/30">
 
+        {/* Brand mark */}
+        <div className="mb-8 flex flex-col items-center gap-4">
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-[var(--primary)] text-[var(--primary-foreground)] shadow-sm">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="h-6 w-6"
+              aria-hidden="true"
+            >
+              <rect x="2" y="7" width="20" height="14" rx="2" ry="2" />
+              <path d="M16 7V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v2" />
+            </svg>
+          </div>
+          <div className="text-center">
+            <h1 className="text-2xl font-bold tracking-tight text-[var(--card-foreground)]">
+              Create your account
+            </h1>
+            <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+              Start tracking your job applications
+            </p>
+          </div>
+        </div>
+
+        {/* Error banner */}
         {error && (
-          <div className="mb-4 rounded-md border border-[var(--destructive)]/30 bg-[var(--destructive)]/10 px-4 py-3 text-sm text-[var(--destructive)]">
+          <div className="mb-5 flex items-start gap-3 rounded-lg border border-[var(--destructive)]/30 bg-[var(--destructive)]/10 px-4 py-3 text-sm text-[var(--destructive)]">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="mt-0.5 h-4 w-4 shrink-0"
+              aria-hidden="true"
+            >
+              <path
+                fillRule="evenodd"
+                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0110 5zm0 10a1 1 0 100-2 1 1 0 000 2z"
+                clipRule="evenodd"
+              />
+            </svg>
             {error}
           </div>
         )}
 
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-5">
           <Input
             label="Email"
             type="email"
@@ -93,15 +139,25 @@ export default function RegisterPage() {
             error={fieldErrors.password}
             required
           />
-          <Button type="submit" loading={loading} size="lg" className="mt-2 w-full">
-            {loading ? 'Creating account...' : 'Register'}
+          <Button type="submit" loading={loading} size="lg" className="mt-1 w-full">
+            {loading ? 'Creating account...' : 'Create account'}
           </Button>
         </form>
 
-        <p className="mt-4 text-center text-sm text-[var(--muted-foreground)]">
+        {/* Divider */}
+        <div className="my-6 flex items-center gap-3" aria-hidden="true">
+          <div className="h-px flex-1 bg-[var(--border)]" />
+          <span className="text-xs text-[var(--muted-foreground)]">or</span>
+          <div className="h-px flex-1 bg-[var(--border)]" />
+        </div>
+
+        <p className="text-center text-sm text-[var(--muted-foreground)]">
           Already have an account?{' '}
-          <Link href="/login" className="font-medium text-[var(--primary)] hover:underline">
-            Login
+          <Link
+            href="/login"
+            className="font-semibold text-[var(--primary)] transition-opacity duration-150 hover:opacity-75 focus-visible:rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+          >
+            Sign in
           </Link>
         </p>
       </div>


### PR DESCRIPTION
## Summary
- Redesign login and register pages: brand logo mark, subtle gradient background, updated headings, improved error banner with icon, "or" divider, refined card shadow
- Update button/link labels to match modern copy: `Login` → `Sign in`, `Register` → `Create account`, `Register` link → `Create one`, `Login` link → `Sign in`
- Fix `login.test.tsx` and `register.test.tsx` to match new UI text

## Test plan
- [x] 187 tests passing across all 22 suites, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)