### PR TITLE
feat(frontend): add CredentialCell with eye-toggle for passwords (Tas…

### DIFF
--- a/frontend/__tests__/applications.credentialCell.test.tsx
+++ b/frontend/__tests__/applications.credentialCell.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CredentialCell from '@/components/applications/CredentialCell';
+
+describe('CredentialCell', () => {
+    // --- No credentials ---
+
+    it('renders a dash when both username and password are null', () => {
+        render(<CredentialCell username={null} password={null} />);
+        expect(screen.getByText('—')).toBeInTheDocument();
+        expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    // --- Default hidden state ---
+
+    it('shows masked values by default when credentials are present', () => {
+        render(<CredentialCell username="alice" password="secret" />);
+        const masks = screen.getAllByText('••••••••');
+        expect(masks).toHaveLength(2);
+    });
+
+    it('does not reveal actual values in hidden state', () => {
+        render(<CredentialCell username="alice" password="secret" />);
+        expect(screen.queryByText('alice')).not.toBeInTheDocument();
+        expect(screen.queryByText('secret')).not.toBeInTheDocument();
+    });
+
+    it('shows "Show credentials" button label in hidden state', () => {
+        render(<CredentialCell username="alice" password="secret" />);
+        expect(screen.getByRole('button', { name: 'Show credentials' })).toBeInTheDocument();
+    });
+
+    // --- Toggling visible ---
+
+    it('reveals credentials after clicking the toggle', () => {
+        render(<CredentialCell username="alice" password="secret" />);
+        fireEvent.click(screen.getByRole('button', { name: 'Show credentials' }));
+        expect(screen.getByText('alice')).toBeInTheDocument();
+        expect(screen.getByText('secret')).toBeInTheDocument();
+        expect(screen.queryByText('••••••••')).not.toBeInTheDocument();
+    });
+
+    it('shows "Hide credentials" button label when visible', () => {
+        render(<CredentialCell username="alice" password="secret" />);
+        fireEvent.click(screen.getByRole('button', { name: 'Show credentials' }));
+        expect(screen.getByRole('button', { name: 'Hide credentials' })).toBeInTheDocument();
+    });
+
+    it('hides credentials again after a second toggle', () => {
+        render(<CredentialCell username="alice" password="secret" />);
+        fireEvent.click(screen.getByRole('button', { name: 'Show credentials' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Hide credentials' }));
+        expect(screen.getAllByText('••••••••')).toHaveLength(2);
+        expect(screen.queryByText('alice')).not.toBeInTheDocument();
+    });
+
+    // --- Username only ---
+
+    it('renders username only when password is null', () => {
+        render(<CredentialCell username="alice" password={null} />);
+        expect(screen.getByText('user:')).toBeInTheDocument();
+        expect(screen.queryByText('pass:')).not.toBeInTheDocument();
+        expect(screen.getAllByText('••••••••')).toHaveLength(1);
+    });
+
+    it('reveals username only credential', () => {
+        render(<CredentialCell username="alice" password={null} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Show credentials' }));
+        expect(screen.getByText('alice')).toBeInTheDocument();
+    });
+
+    // --- Password only ---
+
+    it('renders password only when username is null', () => {
+        render(<CredentialCell username={null} password="secret" />);
+        expect(screen.getByText('pass:')).toBeInTheDocument();
+        expect(screen.queryByText('user:')).not.toBeInTheDocument();
+        expect(screen.getAllByText('••••••••')).toHaveLength(1);
+    });
+
+    it('reveals password only credential', () => {
+        render(<CredentialCell username={null} password="secret" />);
+        fireEvent.click(screen.getByRole('button', { name: 'Show credentials' }));
+        expect(screen.getByText('secret')).toBeInTheDocument();
+    });
+});

--- a/frontend/__tests__/applications.table.test.tsx
+++ b/frontend/__tests__/applications.table.test.tsx
@@ -111,7 +111,7 @@ describe('ApplicationsTable', () => {
             makePage([makeApp({ username: 'user123', password: 'secret' })]),
         );
         render(<ApplicationsTable />);
-        await waitFor(() => expect(screen.getByText('••••••••')).toBeInTheDocument());
+        await waitFor(() => expect(screen.getAllByText('••••••••').length).toBeGreaterThanOrEqual(1));
     });
 
     it('shows dash in credentials column when no credentials', async () => {

--- a/frontend/components/applications/ApplicationsTable.tsx
+++ b/frontend/components/applications/ApplicationsTable.tsx
@@ -6,6 +6,7 @@ import { Application, JobType, PagedResponse, Status } from '@/types';
 import Pagination from '@/components/ui/Pagination';
 import SearchInput from '@/components/ui/SearchInput';
 import Spinner from '@/components/ui/Spinner';
+import CredentialCell from '@/components/applications/CredentialCell';
 import StatusSelect from '@/components/applications/StatusSelect';
 
 type SortDir = 'asc' | 'desc';
@@ -216,8 +217,11 @@ export default function ApplicationsTable() {
                                         <td className={`${tdCls} text-[var(--muted-foreground)]`}>
                                             {JOB_TYPE_LABELS[app.jobType]}
                                         </td>
-                                        <td className={`${tdCls} font-mono text-[var(--muted-foreground)]`}>
-                                            {app.username || app.password ? '••••••••' : '—'}
+                                        <td className={tdCls}>
+                                            <CredentialCell
+                                                username={app.username}
+                                                password={app.password}
+                                            />
                                         </td>
                                         <td className={tdCls}>—</td>
                                     </tr>

--- a/frontend/components/applications/CredentialCell.tsx
+++ b/frontend/components/applications/CredentialCell.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+interface Props {
+    username: string | null;
+    password: string | null;
+}
+
+function EyeIcon() {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+            aria-hidden="true"
+        >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+        </svg>
+    );
+}
+
+function EyeOffIcon() {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+            aria-hidden="true"
+        >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 4.411m0 0L21 21" />
+        </svg>
+    );
+}
+
+export default function CredentialCell({ username, password }: Props) {
+    const [visible, setVisible] = useState(false);
+
+    const toggle = useCallback(() => setVisible(prev => !prev), []);
+
+    if (username === null && password === null) {
+        return <span className="text-[var(--muted-foreground)]">—</span>;
+    }
+
+    return (
+        <div className="flex items-center gap-2">
+            <div className="font-mono text-xs space-y-0.5">
+                {username !== null && (
+                    <div>
+                        <span className="text-[var(--muted-foreground)]">user: </span>
+                        <span>{visible ? username : '••••••••'}</span>
+                    </div>
+                )}
+                {password !== null && (
+                    <div>
+                        <span className="text-[var(--muted-foreground)]">pass: </span>
+                        <span>{visible ? password : '••••••••'}</span>
+                    </div>
+                )}
+            </div>
+
+            <button
+                onClick={toggle}
+                aria-label={visible ? 'Hide credentials' : 'Show credentials'}
+                className="shrink-0 text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+            >
+                {visible ? <EyeOffIcon /> : <EyeIcon />}
+            </button>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

- Add `CredentialCell` component that masks portal credentials (`••••••••`) by default with an eye/eye-off toggle button
- Replace the static inline mask in `ApplicationsTable` with the new component
- Credentials cell shows a dash (`—`) with no toggle when neither username nor password is present

## Details

`CredentialCell` renders username and/or password rows with a shared visibility toggle. State is local and ephemeral — credentials are always hidden on initial render. Supports all three data states: username only, password only, or both.

## Tests

- 11 new unit tests in `applications.credentialCell.test.tsx` covering: no credentials (dash), default masked state, reveal on toggle, re-hide on second toggle, username-only, and password-only variants
- Updated `applications.table.test.tsx` to use `getAllByText` for the masked-credentials assertion (now two masks render when both fields are present)
- All 211 frontend tests pass, lint clean