### PR TITLE
feat(frontend): add StatusHint warning dots for stale APPLIED applications (Task 21)

### DIFF
--- a/frontend/__tests__/applications.statusHint.test.tsx
+++ b/frontend/__tests__/applications.statusHint.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react';
+import StatusHint from '@/components/applications/StatusHint';
+
+const FIXED_TODAY = '2026-03-04';
+
+function dateMinusDays(days: number): string {
+    const d = new Date(FIXED_TODAY);
+    d.setDate(d.getDate() - days);
+    return d.toISOString().slice(0, 10);
+}
+
+beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(FIXED_TODAY));
+});
+
+afterAll(() => {
+    jest.useRealTimers();
+});
+
+describe('StatusHint', () => {
+    // --- Non-APPLIED statuses ---
+
+    it.each(['SCREENING', 'INTERVIEWING', 'OFFER', 'REJECTED', 'WITHDRAWN'] as const)(
+        'renders nothing for status %s',
+        (status) => {
+            const { container } = render(
+                <StatusHint status={status} appliedDate={dateMinusDays(40)} />,
+            );
+            expect(container.firstChild).toBeNull();
+        },
+    );
+
+    // --- APPLIED within 14 days ---
+
+    it('renders nothing when APPLIED 0 days ago', () => {
+        const { container } = render(
+            <StatusHint status="APPLIED" appliedDate={dateMinusDays(0)} />,
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing when APPLIED 13 days ago', () => {
+        const { container } = render(
+            <StatusHint status="APPLIED" appliedDate={dateMinusDays(13)} />,
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    // --- Amber: 14–29 days ---
+
+    it('renders amber dot when APPLIED 14 days ago', () => {
+        render(<StatusHint status="APPLIED" appliedDate={dateMinusDays(14)} />);
+        const dot = screen.getByRole('img', { name: /14 days ago — consider following up/i });
+        expect(dot).toBeInTheDocument();
+        expect(dot).toHaveClass('bg-amber-500');
+    });
+
+    it('renders amber dot when APPLIED 29 days ago', () => {
+        render(<StatusHint status="APPLIED" appliedDate={dateMinusDays(29)} />);
+        const dot = screen.getByRole('img', { name: /29 days ago — consider following up/i });
+        expect(dot).toBeInTheDocument();
+        expect(dot).toHaveClass('bg-amber-500');
+    });
+
+    it('amber dot has correct tooltip text', () => {
+        render(<StatusHint status="APPLIED" appliedDate={dateMinusDays(20)} />);
+        const dot = screen.getByRole('img');
+        expect(dot).toHaveAttribute('title', 'Applied 20 days ago — consider following up');
+    });
+
+    // --- Red: 30+ days ---
+
+    it('renders red dot when APPLIED 30 days ago', () => {
+        render(<StatusHint status="APPLIED" appliedDate={dateMinusDays(30)} />);
+        const dot = screen.getByRole('img', { name: /30 days ago — may be ghosted/i });
+        expect(dot).toBeInTheDocument();
+        expect(dot).toHaveClass('bg-red-500');
+    });
+
+    it('renders red dot when APPLIED 60 days ago', () => {
+        render(<StatusHint status="APPLIED" appliedDate={dateMinusDays(60)} />);
+        const dot = screen.getByRole('img', { name: /60 days ago — may be ghosted/i });
+        expect(dot).toBeInTheDocument();
+        expect(dot).toHaveClass('bg-red-500');
+    });
+
+    it('red dot has correct tooltip text', () => {
+        render(<StatusHint status="APPLIED" appliedDate={dateMinusDays(45)} />);
+        const dot = screen.getByRole('img');
+        expect(dot).toHaveAttribute('title', 'Applied 45 days ago — may be ghosted');
+    });
+
+    it('does not show amber dot when 30+ days (only red)', () => {
+        render(<StatusHint status="APPLIED" appliedDate={dateMinusDays(30)} />);
+        const dots = screen.getAllByRole('img');
+        expect(dots).toHaveLength(1);
+        expect(dots[0]).toHaveClass('bg-red-500');
+        expect(dots[0]).not.toHaveClass('bg-amber-500');
+    });
+});

--- a/frontend/components/applications/ApplicationsTable.tsx
+++ b/frontend/components/applications/ApplicationsTable.tsx
@@ -7,6 +7,7 @@ import Pagination from '@/components/ui/Pagination';
 import SearchInput from '@/components/ui/SearchInput';
 import Spinner from '@/components/ui/Spinner';
 import CredentialCell from '@/components/applications/CredentialCell';
+import StatusHint from '@/components/applications/StatusHint';
 import StatusSelect from '@/components/applications/StatusSelect';
 
 type SortDir = 'asc' | 'desc';
@@ -201,7 +202,12 @@ export default function ApplicationsTable() {
                                         key={app.id}
                                         className="hover:bg-[var(--muted)]/30 transition-colors"
                                     >
-                                        <td className={`${tdCls} font-medium`}>{app.companyName}</td>
+                                        <td className={`${tdCls} font-medium`}>
+                                            <span className="flex items-center gap-1.5">
+                                                <StatusHint status={app.status} appliedDate={app.appliedDate} />
+                                                {app.companyName}
+                                            </span>
+                                        </td>
                                         <td className={tdCls}>{app.jobRole}</td>
                                         <td className={tdCls}>
                                             <StatusSelect

--- a/frontend/components/applications/StatusHint.tsx
+++ b/frontend/components/applications/StatusHint.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { Status } from '@/types';
+
+interface Props {
+    status: Status;
+    appliedDate: string; // 'YYYY-MM-DD'
+}
+
+function daysSince(dateStr: string): number {
+    const applied = new Date(dateStr);
+    applied.setHours(0, 0, 0, 0);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return Math.floor((today.getTime() - applied.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+export default function StatusHint({ status, appliedDate }: Props) {
+    if (status !== 'APPLIED') return null;
+
+    const days = daysSince(appliedDate);
+
+    if (days >= 30) {
+        return (
+            <span
+                className="inline-block h-2 w-2 rounded-full bg-red-500 shrink-0"
+                title={`Applied ${days} days ago — may be ghosted`}
+                aria-label={`Applied ${days} days ago — may be ghosted`}
+                role="img"
+            />
+        );
+    }
+
+    if (days >= 14) {
+        return (
+            <span
+                className="inline-block h-2 w-2 rounded-full bg-amber-500 shrink-0"
+                title={`Applied ${days} days ago — consider following up`}
+                aria-label={`Applied ${days} days ago — consider following up`}
+                role="img"
+            />
+        );
+    }
+
+    return null;
+}


### PR DESCRIPTION
## Summary

- Add `StatusHint` component that renders a coloured warning dot next to the company name for APPLIED applications that have gone stale
- Amber dot (14–29 days): tooltip "Applied X days ago — consider following up"
- Red dot (30+ days): tooltip "Applied X days ago — may be ghosted"
- Renders nothing for all non-APPLIED statuses and for applications applied within 14 days

## Details

`StatusHint` calculates days elapsed since `appliedDate` (midnight-normalised, date-only arithmetic). The dot is rendered as a `<span role="img">` with both `aria-label` and `title` for accessibility and native hover tooltips. Placed inline before the company name in the Company column of `ApplicationsTable`.

## Tests

- 14 new unit tests in `applications.statusHint.test.tsx` covering: all non-APPLIED statuses, boundary days (0, 13, 14, 29, 30, 60), correct dot colour per threshold, correct tooltip text, and that only one dot renders at the 30+ day boundary
- System time fixed to `2026-03-04` via `jest.setSystemTime` for deterministic date arithmetic
- All 225 frontend tests pass, lint clean