### PR TITLE
feat(frontend): add RowActionMenu kebab dropdown (Task 22)

### DIFF
--- a/frontend/__tests__/applications.rowActionMenu.test.tsx
+++ b/frontend/__tests__/applications.rowActionMenu.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import RowActionMenu from '@/components/applications/RowActionMenu';
+
+const defaultProps = {
+    websiteLink: 'https://example.com',
+    onEdit: jest.fn(),
+    onDelete: jest.fn(),
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('RowActionMenu', () => {
+    // --- Closed state ---
+
+    it('renders the kebab button', () => {
+        render(<RowActionMenu {...defaultProps} />);
+        expect(screen.getByRole('button', { name: 'Row actions' })).toBeInTheDocument();
+    });
+
+    it('does not show the dropdown initially', () => {
+        render(<RowActionMenu {...defaultProps} />);
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('has aria-expanded=false initially', () => {
+        render(<RowActionMenu {...defaultProps} />);
+        expect(screen.getByRole('button', { name: 'Row actions' })).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    // --- Opening ---
+
+    it('opens the dropdown when the kebab button is clicked', () => {
+        render(<RowActionMenu {...defaultProps} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Row actions' }));
+        expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+
+    it('shows Edit, Open Website, and Delete menu items when open', () => {
+        render(<RowActionMenu {...defaultProps} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Row actions' }));
+        expect(screen.getByRole('menuitem', { name: 'Edit' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Open Website' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
+    });
+
+    it('sets aria-expanded=true when open', () => {
+        render(<RowActionMenu {...defaultProps} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Row actions' }));
+        expect(screen.getByRole('button', { name: 'Row actions' })).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    // --- Closing ---
+
+    it('closes when the kebab button is clicked again', () => {
+        render(<RowActionMenu {...defaultProps} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Row actions' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Row actions' }));
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('closes on Escape key', () => {
+        render(<RowActionMenu {...defaultProps} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Row actions' }));
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('closes on outside mousedown', () => {
+        render(<RowActionMenu {...defaultProps} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Row actions' }));
+        fireEvent.mouseDown(document.body);
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    // --- Edit ---
+
+    it('calls onEdit and closes when Edit is clicked', () => {
+        const onEdit = jest.fn();
+        render(<RowActionMenu {...defaultProps} onEdit={onEdit} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Row actions' }));
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Edit' }));
+        expect(onEdit).toHaveBeenCalledTimes(1);
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    // --- Delete ---
+
+    it('calls onDelete and closes when Delete is clicked', () => {
+        const onDelete = jest.fn();
+        render(<RowActionMenu {...defaultProps} onDelete={onDelete} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Row actions' }));
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+        expect(onDelete).toHaveBeenCalledTimes(1);
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    // --- Open Website ---
+
+    it('opens website in a new tab and closes when Open Website is clicked', () => {
+        const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+        render(<RowActionMenu {...defaultProps} websiteLink="https://example.com" />);
+        fireEvent.click(screen.getByRole('button', { name: 'Row actions' }));
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Open Website' }));
+        expect(openSpy).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer');
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+        openSpy.mockRestore();
+    });
+
+    it('disables Open Website when websiteLink is null', () => {
+        render(<RowActionMenu {...defaultProps} websiteLink={null} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Row actions' }));
+        expect(screen.getByRole('menuitem', { name: 'Open Website' })).toBeDisabled();
+    });
+
+    it('does not call window.open when Open Website is disabled', () => {
+        const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+        render(<RowActionMenu {...defaultProps} websiteLink={null} />);
+        fireEvent.click(screen.getByRole('button', { name: 'Row actions' }));
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Open Website' }));
+        expect(openSpy).not.toHaveBeenCalled();
+        openSpy.mockRestore();
+    });
+});

--- a/frontend/__tests__/applications.table.test.tsx
+++ b/frontend/__tests__/applications.table.test.tsx
@@ -120,8 +120,7 @@ describe('ApplicationsTable', () => {
         );
         render(<ApplicationsTable />);
         await waitFor(() => screen.getByText('Acme Corp'));
-        // Both credentials and actions columns show "—" when there are no credentials
-        expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
+        expect(screen.getByText('—')).toBeInTheDocument();
     });
 
     it('shows empty state when no applications', async () => {

--- a/frontend/components/applications/ApplicationsTable.tsx
+++ b/frontend/components/applications/ApplicationsTable.tsx
@@ -7,6 +7,7 @@ import Pagination from '@/components/ui/Pagination';
 import SearchInput from '@/components/ui/SearchInput';
 import Spinner from '@/components/ui/Spinner';
 import CredentialCell from '@/components/applications/CredentialCell';
+import RowActionMenu from '@/components/applications/RowActionMenu';
 import StatusHint from '@/components/applications/StatusHint';
 import StatusSelect from '@/components/applications/StatusSelect';
 
@@ -229,7 +230,13 @@ export default function ApplicationsTable() {
                                                 password={app.password}
                                             />
                                         </td>
-                                        <td className={tdCls}>—</td>
+                                        <td className={tdCls}>
+                                            <RowActionMenu
+                                                websiteLink={app.websiteLink}
+                                                onEdit={() => {}}
+                                                onDelete={() => {}}
+                                            />
+                                        </td>
                                     </tr>
                                 ))}
                             </tbody>

--- a/frontend/components/applications/RowActionMenu.tsx
+++ b/frontend/components/applications/RowActionMenu.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface Props {
+    websiteLink: string | null;
+    onEdit: () => void;
+    onDelete: () => void;
+}
+
+function KebabIcon() {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-4 w-4"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+        >
+            <circle cx="12" cy="5" r="1.5" />
+            <circle cx="12" cy="12" r="1.5" />
+            <circle cx="12" cy="19" r="1.5" />
+        </svg>
+    );
+}
+
+export default function RowActionMenu({ websiteLink, onEdit, onDelete }: Props) {
+    const [open, setOpen] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    const close = useCallback(() => setOpen(false), []);
+
+    const toggle = useCallback(() => setOpen(prev => !prev), []);
+
+    // Close on outside click
+    useEffect(() => {
+        if (!open) return;
+        function onMouseDown(e: MouseEvent) {
+            if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+                setOpen(false);
+            }
+        }
+        document.addEventListener('mousedown', onMouseDown);
+        return () => document.removeEventListener('mousedown', onMouseDown);
+    }, [open]);
+
+    // Close on Escape
+    useEffect(() => {
+        if (!open) return;
+        function onKeyDown(e: KeyboardEvent) {
+            if (e.key === 'Escape') setOpen(false);
+        }
+        document.addEventListener('keydown', onKeyDown);
+        return () => document.removeEventListener('keydown', onKeyDown);
+    }, [open]);
+
+    const handleEdit = useCallback(() => {
+        close();
+        onEdit();
+    }, [close, onEdit]);
+
+    const handleDelete = useCallback(() => {
+        close();
+        onDelete();
+    }, [close, onDelete]);
+
+    const handleOpenWebsite = useCallback(() => {
+        if (!websiteLink) return;
+        close();
+        window.open(websiteLink, '_blank', 'noopener,noreferrer');
+    }, [close, websiteLink]);
+
+    return (
+        <div ref={containerRef} className="relative inline-block">
+            <button
+                onClick={toggle}
+                aria-label="Row actions"
+                aria-expanded={open}
+                aria-haspopup="menu"
+                className="rounded p-1 text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--muted)] transition-colors"
+            >
+                <KebabIcon />
+            </button>
+
+            {open && (
+                <div
+                    role="menu"
+                    className={[
+                        'absolute right-0 z-20 mt-1 w-40 rounded-md border border-[var(--border)]',
+                        'bg-[var(--card)] shadow-md',
+                    ].join(' ')}
+                >
+                    <button
+                        role="menuitem"
+                        onClick={handleEdit}
+                        className="w-full px-3 py-2 text-left text-sm text-[var(--foreground)] hover:bg-[var(--muted)] transition-colors"
+                    >
+                        Edit
+                    </button>
+
+                    <button
+                        role="menuitem"
+                        onClick={handleOpenWebsite}
+                        disabled={!websiteLink}
+                        className={[
+                            'w-full px-3 py-2 text-left text-sm transition-colors',
+                            websiteLink
+                                ? 'text-[var(--foreground)] hover:bg-[var(--muted)]'
+                                : 'text-[var(--muted-foreground)] cursor-not-allowed',
+                        ].join(' ')}
+                    >
+                        Open Website
+                    </button>
+
+                    <button
+                        role="menuitem"
+                        onClick={handleDelete}
+                        className="w-full px-3 py-2 text-left text-sm text-red-500 hover:bg-[var(--muted)] transition-colors"
+                    >
+                        Delete
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Adds a `RowActionMenu` component that replaces the static `—` placeholder in the Actions column with a kebab (⋮) button dropdown. Each row now exposes Edit, Open Website, and Delete actions — with the actual implementation of Edit and Delete deferred to Tasks 23–24.

## Changes

### Frontend
- **`RowActionMenu.tsx`** — new component: kebab trigger button, dropdown menu with Edit / Open Website / Delete items, closes on outside `mousedown`, `Escape` key, or item selection; `Open Website` opens `websiteLink` in a new tab with `noopener,noreferrer` and is disabled when `websiteLink` is `null`; `aria-expanded` and `aria-haspopup="menu"` for accessibility
- **`ApplicationsTable.tsx`** — import and render `RowActionMenu` in the Actions column; `onEdit` / `onDelete` are no-op stubs (wired in Tasks 23–24)
- **`applications.rowActionMenu.test.tsx`** — 14 new unit tests covering all interaction paths
- **`applications.table.test.tsx`** — fix stale assertion that expected `—` in the Actions column (now renders a button)

## Testing

- [x] Frontend tests pass — 239/239 (`npm test`)
- [ ] Backend tests pass — no backend changes
- [ ] Manual testing performed

## Checklist
- [x] No hardcoded secrets or credentials
- [x] DTOs used (no entities in API responses)
- [x] Constructor injection only (no @Autowired)
- [x] API calls use Axios instance from `lib/api.ts`
- [x] New component has corresponding tests
- [x] Follows project conventions per CLAUDE.md