### PR TITLE
feat(frontend): add create application page (Task 26)

### DIFF
--- a/frontend/__tests__/applications.newPage.test.tsx
+++ b/frontend/__tests__/applications.newPage.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import NewApplicationPage from '@/app/(app)/applications/new/page';
 import { createApplication } from '@/lib/applicationService';
+import { isAuthenticated } from '@/lib/auth';
 
 jest.mock('@/lib/applicationService', () => ({
     createApplication: jest.fn(),
@@ -22,16 +23,24 @@ jest.mock('@/context/ToastContext', () => ({
 }));
 
 jest.mock('@/lib/auth', () => ({
-    isAuthenticated: () => true,
+    isAuthenticated: jest.fn(() => true),
 }));
 
+const mockIsAuthenticated = isAuthenticated as jest.Mock;
 const mockCreateApplication = createApplication as jest.Mock;
 
 beforeEach(() => {
     jest.clearAllMocks();
+    mockIsAuthenticated.mockReturnValue(true);
 });
 
 describe('NewApplicationPage', () => {
+    it('redirects to /login when not authenticated', () => {
+        mockIsAuthenticated.mockReturnValueOnce(false);
+        render(<NewApplicationPage />);
+        expect(mockPush).toHaveBeenCalledWith('/login');
+    });
+
     it('renders the page heading and main form fields', () => {
         render(<NewApplicationPage />);
 
@@ -45,9 +54,10 @@ describe('NewApplicationPage', () => {
         expect(screen.getByLabelText(/website link/i)).toBeInTheDocument();
     });
 
-    it('defaults applied date to today', () => {
+    it('defaults applied date to today (local time)', () => {
         render(<NewApplicationPage />);
-        const today = new Date().toISOString().split('T')[0];
+        const d = new Date();
+        const today = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
         expect(screen.getByLabelText(/applied date/i)).toHaveValue(today);
     });
 
@@ -113,7 +123,6 @@ describe('NewApplicationPage', () => {
         fireEvent.change(screen.getByLabelText(/company name/i), { target: { value: 'Acme' } });
         fireEvent.change(screen.getByLabelText(/job role/i), { target: { value: 'Dev' } });
         fireEvent.change(screen.getByLabelText(/location/i), { target: { value: 'NYC' } });
-        // website link left blank
 
         fireEvent.click(screen.getByRole('button', { name: /create application/i }));
 
@@ -138,10 +147,9 @@ describe('NewApplicationPage', () => {
         fireEvent.click(screen.getByRole('button', { name: /create application/i }));
 
         await waitFor(() => {
-            expect(mockToast.error).toHaveBeenCalledWith('Failed to create application');
+            expect(mockToast.error).toHaveBeenCalled();
+            expect(mockPush).not.toHaveBeenCalled();
         });
-
-        expect(mockPush).not.toHaveBeenCalled();
     });
 
     it('shows validation errors when required fields are empty', async () => {

--- a/frontend/app/(app)/applications/new/page.tsx
+++ b/frontend/app/(app)/applications/new/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { isAuthenticated } from '@/lib/auth';
 import { createApplication } from '@/lib/applicationService';
 import { useToast } from '@/context/ToastContext';
+import { getErrorMessage } from '@/lib/errorMessages';
 import ApplicationForm, { ApplicationFormValues } from '@/components/applications/ApplicationForm';
 
 export default function NewApplicationPage() {
@@ -33,8 +34,8 @@ export default function NewApplicationPage() {
             });
             toast.success('Application created');
             router.push('/dashboard');
-        } catch {
-            toast.error('Failed to create application');
+        } catch (error) {
+            toast.error(getErrorMessage(error));
         }
     }, [router, toast]);
 

--- a/frontend/components/applications/ApplicationForm.tsx
+++ b/frontend/components/applications/ApplicationForm.tsx
@@ -44,7 +44,8 @@ const JOB_TYPE_OPTIONS = [
 ];
 
 function todayIso(): string {
-    return new Date().toISOString().split('T')[0];
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 }
 
 function initialValues(app?: Application): ApplicationFormValues {
@@ -74,23 +75,6 @@ function validate(values: ApplicationFormValues): Errors {
     }
     return errors;
 }
-
-const ChevronDown = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="16"
-        height="16"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        aria-hidden="true"
-    >
-        <polyline points="6 9 12 15 18 9" />
-    </svg>
-);
 
 export default function ApplicationForm({ defaultValues, onSubmit, onCancel, submitLabel = 'Save', collapsibleCredentials = false }: Props) {
     const [values, setValues] = useState<ApplicationFormValues>(() => initialValues(defaultValues));
@@ -201,9 +185,21 @@ export default function ApplicationForm({ defaultValues, onSubmit, onCancel, sub
                         className="w-full flex items-center justify-between px-4 py-3 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--muted)] transition-colors"
                     >
                         <span>Portal Credentials</span>
-                        <span className={`transition-transform duration-200 ${credentialsOpen ? 'rotate-180' : ''}`}>
-                            <ChevronDown />
-                        </span>
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="16"
+                            height="16"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            aria-hidden="true"
+                            className={`transition-transform duration-200 ${credentialsOpen ? 'rotate-180' : ''}`}
+                        >
+                            <polyline points="6 9 12 15 18 9" />
+                        </svg>
                     </button>
                     {credentialsOpen && (
                         <div className="border-t border-[var(--border)] px-4 py-4 grid grid-cols-1 gap-4 sm:grid-cols-2">


### PR DESCRIPTION
## Summary
- Adds `/applications/new` page with ApplicationForm, POST /applications, success toast, and redirect to /dashboard
- Extends ApplicationForm with `collapsibleCredentials` prop — wraps portal username/password in a toggleable section (collapsed by default), leaving EditModal usage unchanged
- Defaults `appliedDate` to today (local time) when no defaultValues provided
- Uses `getErrorMessage()` for structured backend error handling

## Test plan
- [ ] 280 tests pass
- [ ] Lint clean
- [ ] Navigate to /applications/new — form renders with today pre-filled, status APPLIED
- [ ] Submit valid form — toast 'Application created' and redirect to /dashboard
- [ ] Click 'Portal Credentials' toggle — username and password appear; click again — collapse
- [ ] Submit with empty required fields — inline validation errors
- [ ] Click Cancel — redirect to /dashboard

Closes #63

Generated with [Claude Code](https://claude.com/claude-code)