### PR TITLE
feat(frontend): add settings appearance page with theme radio group (Task 27)

### DIFF
--- a/frontend/__tests__/settings.appearance.test.tsx
+++ b/frontend/__tests__/settings.appearance.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import SettingsPage from '@/app/(app)/settings/page';
+
+const mockSetTheme = jest.fn();
+let mockTheme = 'system';
+
+jest.mock('@/context/ThemeContext', () => ({
+    useTheme: () => ({ theme: mockTheme, setTheme: mockSetTheme }),
+}));
+
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@/lib/auth', () => ({
+    isAuthenticated: jest.fn(() => true),
+}));
+
+import { isAuthenticated } from '@/lib/auth';
+const mockIsAuthenticated = isAuthenticated as jest.Mock;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockTheme = 'system';
+    mockIsAuthenticated.mockReturnValue(true);
+});
+
+describe('SettingsPage — Appearance', () => {
+    it('redirects to /login when not authenticated', () => {
+        mockIsAuthenticated.mockReturnValueOnce(false);
+        render(<SettingsPage />);
+        expect(mockPush).toHaveBeenCalledWith('/login');
+    });
+
+    it('renders the Settings heading and Appearance section', () => {
+        render(<SettingsPage />);
+        expect(screen.getByRole('heading', { name: /settings/i })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: /appearance/i })).toBeInTheDocument();
+    });
+
+    it('renders Light, Dark, and System radio options', () => {
+        render(<SettingsPage />);
+        expect(screen.getByRole('radio', { name: /light/i })).toBeInTheDocument();
+        expect(screen.getByRole('radio', { name: /dark/i })).toBeInTheDocument();
+        expect(screen.getByRole('radio', { name: /system/i })).toBeInTheDocument();
+    });
+
+    it('checks the radio matching the current theme', () => {
+        mockTheme = 'dark';
+        render(<SettingsPage />);
+        expect(screen.getByRole('radio', { name: /dark/i })).toBeChecked();
+        expect(screen.getByRole('radio', { name: /light/i })).not.toBeChecked();
+        expect(screen.getByRole('radio', { name: /system/i })).not.toBeChecked();
+    });
+
+    it('calls setTheme with "light" when Light radio is selected', () => {
+        render(<SettingsPage />);
+        fireEvent.click(screen.getByRole('radio', { name: /light/i }));
+        expect(mockSetTheme).toHaveBeenCalledWith('light');
+    });
+
+    it('calls setTheme with "dark" when Dark radio is selected', () => {
+        render(<SettingsPage />);
+        fireEvent.click(screen.getByRole('radio', { name: /dark/i }));
+        expect(mockSetTheme).toHaveBeenCalledWith('dark');
+    });
+
+    it('calls setTheme with "system" when System radio is selected', () => {
+        mockTheme = 'light';
+        render(<SettingsPage />);
+        fireEvent.click(screen.getByRole('radio', { name: /system/i }));
+        expect(mockSetTheme).toHaveBeenCalledWith('system');
+    });
+});

--- a/frontend/app/(app)/settings/page.tsx
+++ b/frontend/app/(app)/settings/page.tsx
@@ -3,9 +3,19 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { isAuthenticated } from '@/lib/auth';
+import { useTheme } from '@/context/ThemeContext';
+
+type ThemeOption = { value: 'light' | 'dark' | 'system'; label: string; description: string };
+
+const THEME_OPTIONS: ThemeOption[] = [
+    { value: 'light', label: 'Light', description: 'Always use the light theme' },
+    { value: 'dark',  label: 'Dark',  description: 'Always use the dark theme' },
+    { value: 'system', label: 'System', description: 'Follow your device preference' },
+];
 
 export default function SettingsPage() {
     const router = useRouter();
+    const { theme, setTheme } = useTheme();
 
     useEffect(() => {
         if (!isAuthenticated()) {
@@ -14,9 +24,49 @@ export default function SettingsPage() {
     }, [router]);
 
     return (
-        <div className="p-8">
-            <h1 className="text-2xl font-bold">Settings</h1>
-            <p className="text-gray-500 mt-2">Coming soon.</p>
+        <div className="max-w-2xl mx-auto px-4 py-8 space-y-8">
+            <h1 className="text-2xl font-bold text-[var(--foreground)]">Settings</h1>
+
+            <section aria-labelledby="appearance-heading">
+                <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 space-y-4">
+                    <h2 id="appearance-heading" className="text-base font-semibold text-[var(--foreground)]">
+                        Appearance
+                    </h2>
+                    <p className="text-sm text-[var(--muted-foreground)]">
+                        Choose how the interface looks. Changes apply immediately.
+                    </p>
+
+                    <fieldset>
+                        <legend className="sr-only">Theme</legend>
+                        <div className="space-y-2">
+                            {THEME_OPTIONS.map(({ value, label, description }) => (
+                                <label
+                                    key={value}
+                                    className={[
+                                        'flex items-center gap-4 rounded-lg border px-4 py-3 cursor-pointer transition-colors',
+                                        theme === value
+                                            ? 'border-[var(--primary)] bg-[var(--primary)]/5'
+                                            : 'border-[var(--border)] hover:bg-[var(--muted)]',
+                                    ].join(' ')}
+                                >
+                                    <input
+                                        type="radio"
+                                        name="theme"
+                                        value={value}
+                                        checked={theme === value}
+                                        onChange={() => setTheme(value)}
+                                        className="accent-[var(--primary)]"
+                                    />
+                                    <div>
+                                        <p className="text-sm font-medium text-[var(--foreground)]">{label}</p>
+                                        <p className="text-xs text-[var(--muted-foreground)]">{description}</p>
+                                    </div>
+                                </label>
+                            ))}
+                        </div>
+                    </fieldset>
+                </div>
+            </section>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- Replaces the /settings stub with a full Appearance section
- Light / Dark / System radio group powered by useTheme() — applies immediately, persists to localStorage, and syncs to backend via PATCH /me (all handled internally by ThemeContext)
- Proper accessibility: section aria-labelledby, fieldset with sr-only legend, controlled radios

## Test plan
- [ ] 287 tests pass
- [ ] Lint clean
- [ ] Navigate to /settings — Appearance section visible with 3 radio options
- [ ] Select Light — page switches to light theme immediately
- [ ] Select Dark — page switches to dark theme immediately
- [ ] Select System — theme follows device preference
- [ ] Reload page — selected theme persists

Closes #64

Generated with [Claude Code](https://claude.com/claude-code)