### PR TITLE
ci: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,98 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend-test:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'push' ||
+      contains(toJSON(github.event.pull_request.labels.*.name), 'backend') ||
+      true
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_DB: job_tracker_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
+      - name: Run tests with coverage
+        env:
+          DB_URL: jdbc:postgresql://localhost:5432/job_tracker_test
+          DB_USERNAME: postgres
+          DB_PASSWORD: postgres
+          JWT_SECRET: ci-test-secret-key-minimum-32-characters-long
+          JWT_EXPIRATION: 86400000
+        run: ./mvnw clean verify
+
+      - name: Upload JaCoCo report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: backend/target/site/jacoco/
+          retention-days: 7
+
+  frontend-test:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'push' ||
+      contains(toJSON(github.event.pull_request.labels.*.name), 'frontend') ||
+      true
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+        env:
+          NEXT_PUBLIC_API_URL: http://localhost:8080


### PR DESCRIPTION
## Summary
- Add .github/workflows/ci.yml with two jobs:
  - **backend-test**: Java 21, PostgreSQL 17 service container, mvnw clean verify, JaCoCo report upload
  - **frontend-test**: Node 22, npm run lint, npm test, npm run build
- Both jobs run on pushes to main and on PRs targeting main

## After merge
Once merged and the checks run at least once, the job names Backend Tests and Frontend Tests will appear in GitHub branch protection status check search.

Generated with [Claude Code](https://claude.com/claude-code)