### PR TITLE
fix(backend): descriptive error for duplicate registration

### DIFF
--- a/backend/src/main/java/com/nadavramon/job_tracker/service/AuthService.java
+++ b/backend/src/main/java/com/nadavramon/job_tracker/service/AuthService.java
@@ -28,7 +28,7 @@ public class AuthService {
         User user = new User();
         if (userRepository.existsByEmail(request.getEmail()) ||
                 userRepository.existsByUsername(request.getUsername())) {
-            throw new DuplicateResourceException("Registration failed");
+            throw new DuplicateResourceException("Email or username already taken");
         }
         user.setEmail(request.getEmail());
         user.setUsername(request.getUsername());


### PR DESCRIPTION
## Summary
- Changed `DuplicateResourceException` message from vague "Registration failed" to "Email or username already taken"
- This matches the frontend's `errorMessages.ts` mapping so users see "This email or username is already registered." instead of the generic fallback

## Test plan
- [ ] Register with an already-taken email — verify the specific error message appears
- [ ] Register with an already-taken username — same check
- [ ] Register with valid credentials — still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)