### PR TITLE
fix(frontend): resolve hydration mismatch on applications page

### DIFF
--- a/frontend/__tests__/applications.page.test.tsx
+++ b/frontend/__tests__/applications.page.test.tsx
@@ -18,6 +18,10 @@ jest.mock('@/lib/auth', () => ({
     isAuthenticated: jest.fn(() => true),
 }));
 
+jest.mock('@/lib/useMounted', () => ({
+    useMounted: () => true,
+}));
+
 const mockIsAuthenticated = isAuthenticated as jest.Mock;
 
 describe('ApplicationsPage', () => {

--- a/frontend/app/(app)/applications/page.tsx
+++ b/frontend/app/(app)/applications/page.tsx
@@ -3,19 +3,29 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { isAuthenticated } from '@/lib/auth';
+import { useMounted } from '@/lib/useMounted';
 import ApplicationsTable from '@/components/applications/ApplicationsTable';
+import Spinner from '@/components/ui/Spinner';
 
 export default function ApplicationsPage() {
     const router = useRouter();
-    const authenticated = isAuthenticated();
+    const mounted = useMounted();
 
     useEffect(() => {
-        if (!authenticated) {
+        if (mounted && !isAuthenticated()) {
             router.push('/login');
         }
-    }, [authenticated, router]);
+    }, [mounted, router]);
 
-    if (!authenticated) return null;
+    if (!mounted) {
+        return (
+            <div className="flex items-center justify-center py-16">
+                <Spinner size="lg" />
+            </div>
+        );
+    }
+
+    if (!isAuthenticated()) return null;
 
     return (
         <div className="max-w-7xl mx-auto px-4 py-8 space-y-6">


### PR DESCRIPTION
## Summary
- Fix hydration error on `/applications` page caused by `isAuthenticated()` returning different values on server (no `localStorage`) vs client
- Use `useMounted` hook to defer auth check to client-side, rendering a spinner during SSR — same pattern used by Sidebar and other components
- This was breaking the entire page tree, preventing both the applications table and dashboard from rendering

## Test plan
- [ ] Navigate to `/applications` — page loads without hydration errors
- [ ] Applications table renders with data
- [ ] Dashboard page also works (was affected by the broken page tree)
- [ ] Log out, visit `/applications` — redirects to `/login`
- [ ] 331 frontend tests passing, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)