### PR TITLE
fix(frontend): align PagedResponse type with Spring Boot 4 serialization

### DIFF
--- a/frontend/__tests__/applications.table.test.tsx
+++ b/frontend/__tests__/applications.table.test.tsx
@@ -55,16 +55,16 @@ const makeApp = (overrides: Partial<Application> = {}): Application => ({
 
 const makePage = (
     apps: Application[],
-    overrides: Partial<PagedResponse<Application>> = {},
+    pageOverrides: Partial<PagedResponse<Application>['page']> = {},
 ): PagedResponse<Application> => ({
     content: apps,
-    totalElements: apps.length,
-    totalPages: 1,
-    number: 0,
-    size: 20,
-    first: true,
-    last: true,
-    ...overrides,
+    page: {
+        totalElements: apps.length,
+        totalPages: 1,
+        number: 0,
+        size: 20,
+        ...pageOverrides,
+    },
 });
 
 describe('ApplicationsTable', () => {

--- a/frontend/components/applications/ApplicationsTable.tsx
+++ b/frontend/components/applications/ApplicationsTable.tsx
@@ -115,7 +115,7 @@ export default function ApplicationsTable() {
                 return {
                     ...prev,
                     content: prev.content.filter(a => a.id !== pendingDeleteApp.id),
-                    totalElements: prev.totalElements - 1,
+                    page: { ...prev.page, totalElements: prev.page.totalElements - 1 },
                 };
             });
             toast.success('Application deleted');
@@ -217,13 +217,13 @@ export default function ApplicationsTable() {
                 </div>
             )}
 
-            {!loading && !error && (!data || data.totalElements === 0) && (
+            {!loading && !error && (!data || data.page.totalElements === 0) && (
                 <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-8 text-center">
                     <p className="text-[var(--muted-foreground)]">No applications yet.</p>
                 </div>
             )}
 
-            {!loading && !error && data && data.totalElements > 0 && (
+            {!loading && !error && data && data.page.totalElements > 0 && (
                 <>
                     {/* Desktop table */}
                     <div className="hidden md:block rounded-xl md:rounded-b-none border border-[var(--border)] bg-[var(--card)] overflow-hidden">
@@ -322,12 +322,12 @@ export default function ApplicationsTable() {
                                 </select>
                             </div>
 
-                            {data.totalPages > 1 && (
+                            {data.page.totalPages > 1 && (
                                 <Pagination
-                                    page={data.number}
-                                    totalPages={data.totalPages}
-                                    totalElements={data.totalElements}
-                                    pageSize={data.size}
+                                    page={data.page.number}
+                                    totalPages={data.page.totalPages}
+                                    totalElements={data.page.totalElements}
+                                    pageSize={data.page.size}
                                     onPageChange={handlePageChange}
                                 />
                             )}

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -64,15 +64,15 @@ export interface UpdateProfileRequest {
     themePreference?: ThemePreference;
 }
 
-// Mirrors Spring Page<T> response from paginated endpoints
+// Mirrors Spring Page<T> response from paginated endpoints (Spring Boot 4 format)
 export interface PagedResponse<T> {
     content: T[];
-    totalPages: number;
-    totalElements: number;
-    number: number;
-    size: number;
-    first: boolean;
-    last: boolean;
+    page: {
+        totalPages: number;
+        totalElements: number;
+        number: number;
+        size: number;
+    };
 }
 
 // Mirrors MonthlyCount DTO from GET /applications/stats


### PR DESCRIPTION
## Summary
- Spring Boot 4 nests pagination metadata under a `page` key (`{ content, page: { totalElements, totalPages, number, size } }`) instead of flat fields — the frontend `PagedResponse` type was reading flat fields, causing the applications table to not render
- Updated `PagedResponse<T>` type in `types/index.ts` to match the actual API structure
- Updated all usages in `ApplicationsTable.tsx` to read from `data.page.*`
- Updated test helper `makePage()` with narrowed type for page overrides

## Test plan
- [x] All 26 ApplicationsTable tests pass
- [x] Full frontend test suite passes (331 tests)
- [x] Lint clean
- [ ] Manual smoke test: verify applications table renders with real backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)