### PR TITLE
feat: redesign dashboard with premium dark aesthetic

### DIFF
--- a/frontend/__tests__/dashboard.statusChart.test.tsx
+++ b/frontend/__tests__/dashboard.statusChart.test.tsx
@@ -9,9 +9,6 @@ jest.mock('recharts', () => ({
     ),
     Cell: () => null,
     Tooltip: () => null,
-    Legend: ({ formatter }: { formatter: (v: string) => React.ReactNode }) => (
-        <div data-testid="legend">{['Applied', 'Rejected'].map((v) => <span key={v}>{formatter(v)}</span>)}</div>
-    ),
 }));
 
 jest.mock('@/context/ThemeContext', () => ({
@@ -47,10 +44,15 @@ describe('StatusChart', () => {
         expect(pie).toHaveAttribute('data-slices', '2');
     });
 
-    it('renders legend with status labels', () => {
+    it('renders custom legend with status labels', () => {
         render(<StatusChart statusBreakdown={{ APPLIED: 3, REJECTED: 2 }} />);
-        expect(screen.getByTestId('legend')).toBeInTheDocument();
         expect(screen.getByText('Applied')).toBeInTheDocument();
         expect(screen.getByText('Rejected')).toBeInTheDocument();
+    });
+
+    it('renders center label with total count', () => {
+        render(<StatusChart statusBreakdown={{ APPLIED: 3, REJECTED: 2 }} />);
+        expect(screen.getByText('5')).toBeInTheDocument();
+        expect(screen.getByText('Active')).toBeInTheDocument();
     });
 });

--- a/frontend/app/(app)/dashboard/page.tsx
+++ b/frontend/app/(app)/dashboard/page.tsx
@@ -46,24 +46,54 @@ export default function DashboardPage() {
   }
 
   return (
-    <div className="max-w-7xl mx-auto px-4 py-8 space-y-6">
-      {error && (
-        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-400">
-          {error}
-        </div>
-      )}
+    <div className="dashboard-scope relative min-h-full">
+      <div
+        className="-mx-4 -mt-8 px-4 pt-8 pb-8"
+        style={{ background: 'var(--dash-bg)' }}
+      >
+        {/* Mesh gradient — top-left */}
+        <div
+          className="pointer-events-none absolute -left-40 -top-40 h-[600px] w-[600px] rounded-full"
+          style={{ background: 'radial-gradient(circle, var(--dash-mesh-1) 0%, transparent 70%)' }}
+          aria-hidden="true"
+        />
+        {/* Mesh gradient — bottom-right */}
+        <div
+          className="pointer-events-none absolute -bottom-40 -right-40 h-[600px] w-[600px] rounded-full"
+          style={{ background: 'radial-gradient(circle, var(--dash-mesh-2) 0%, transparent 70%)' }}
+          aria-hidden="true"
+        />
 
-      {stats && (
-        <>
-          <StatsBar stats={stats} />
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <ApplicationsChart data={stats.monthlyApplications} />
-            <StatusChart statusBreakdown={stats.statusBreakdown} />
+        <div className="relative max-w-7xl mx-auto space-y-8">
+          {/* Page header */}
+          <div className="animate-[fade-in_0.4s_ease-out]">
+            <h1 className="text-2xl font-bold text-[var(--dash-heading)]">Dashboard</h1>
+            <p className="mt-1 text-sm text-[var(--dash-subtext)]">
+              Track your job application progress
+            </p>
           </div>
-        </>
-      )}
 
-      <ApplicationsTable onDataChange={fetchStats} />
+          {error && (
+            <div className="rounded-xl border border-[var(--dash-card-border)] bg-[var(--dash-card)] px-4 py-3 text-sm text-red-400">
+              {error}
+            </div>
+          )}
+
+          {stats && (
+            <>
+              <StatsBar stats={stats} />
+              <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+                <div className="lg:col-span-2">
+                  <ApplicationsChart data={stats.monthlyApplications} />
+                </div>
+                <StatusChart statusBreakdown={stats.statusBreakdown} />
+              </div>
+            </>
+          )}
+
+          <ApplicationsTable onDataChange={fetchStats} title="Application Tracker" />
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -37,6 +37,27 @@
   --auth-glow: rgba(0, 82, 204, 0.3);
   --auth-mesh-1: rgba(0, 82, 204, 0.08);
   --auth-mesh-2: rgba(18, 183, 106, 0.05);
+
+  --dash-bg: #f0f4f8;
+  --dash-card: #ffffff;
+  --dash-card-alt: rgba(255, 255, 255, 0.85);
+  --dash-card-border: rgba(37, 99, 235, 0.08);
+  --dash-card-hover-border: rgba(37, 99, 235, 0.15);
+  --dash-heading: #0f172a;
+  --dash-subtext: #64748b;
+  --dash-primary: #2563eb;
+  --dash-primary-dim: #3b82f6;
+  --dash-primary-glow: rgba(37, 99, 235, 0.12);
+  --dash-secondary: #d97706;
+  --dash-tertiary: #16a34a;
+  --dash-mesh-1: rgba(37, 99, 235, 0.06);
+  --dash-mesh-2: rgba(22, 163, 106, 0.04);
+  --dash-chart-grid: #e2e8f0;
+  --dash-chart-axis: #94a3b8;
+  --dash-table-header-bg: rgba(241, 245, 249, 0.8);
+  --dash-table-row-hover: rgba(37, 99, 235, 0.04);
+  --dash-progress-track: #e2e8f0;
+  --dash-stat-circle: rgba(37, 99, 235, 0.06);
 }
 
 .dark {
@@ -75,6 +96,27 @@
   --auth-glow: rgba(133, 173, 255, 0.4);
   --auth-mesh-1: rgba(133, 173, 255, 0.15);
   --auth-mesh-2: rgba(155, 255, 206, 0.08);
+
+  --dash-bg: #060e20;
+  --dash-card: #091328;
+  --dash-card-alt: rgba(15, 25, 48, 0.6);
+  --dash-card-border: rgba(133, 173, 255, 0.08);
+  --dash-card-hover-border: rgba(133, 173, 255, 0.15);
+  --dash-heading: #dee5ff;
+  --dash-subtext: #94a3b8;
+  --dash-primary: #85adff;
+  --dash-primary-dim: #699cff;
+  --dash-primary-glow: rgba(133, 173, 255, 0.15);
+  --dash-secondary: #f8a010;
+  --dash-tertiary: #9bffce;
+  --dash-mesh-1: rgba(133, 173, 255, 0.08);
+  --dash-mesh-2: rgba(155, 255, 206, 0.05);
+  --dash-chart-grid: rgba(133, 173, 255, 0.06);
+  --dash-chart-axis: #64748b;
+  --dash-table-header-bg: rgba(15, 25, 48, 0.8);
+  --dash-table-row-hover: rgba(133, 173, 255, 0.04);
+  --dash-progress-track: rgba(133, 173, 255, 0.1);
+  --dash-stat-circle: rgba(133, 173, 255, 0.06);
 }
 
 
@@ -83,6 +125,18 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+}
+
+.dashboard-scope {
+  --card: var(--dash-card);
+  --card-foreground: var(--dash-heading);
+  --border: var(--dash-card-border);
+  --muted: var(--dash-table-header-bg);
+  --muted-foreground: var(--dash-subtext);
+  --primary: var(--dash-primary);
+  --background: var(--dash-bg);
+  --foreground: var(--dash-heading);
+  --ring: var(--dash-primary);
 }
 
 body {

--- a/frontend/components/applications/ApplicationsTable.tsx
+++ b/frontend/components/applications/ApplicationsTable.tsx
@@ -19,9 +19,10 @@ const tdCls = 'px-4 py-3 text-sm text-[var(--foreground)] whitespace-nowrap';
 
 interface ApplicationsTableProps {
     onDataChange?: () => void;
+    title?: string;
 }
 
-export default function ApplicationsTable({ onDataChange }: ApplicationsTableProps) {
+export default function ApplicationsTable({ onDataChange, title }: ApplicationsTableProps) {
     const {
         data,
         loading,
@@ -50,6 +51,12 @@ export default function ApplicationsTable({ onDataChange }: ApplicationsTablePro
     return (
         <>
         <div className="space-y-4">
+            {title && (
+                <div>
+                    <h2 className="text-lg font-bold text-[var(--foreground)]">{title}</h2>
+                    <p className="mt-0.5 text-xs text-[var(--muted-foreground)]">Manage and track your applications</p>
+                </div>
+            )}
             <ApplicationsToolbar
                 search={search}
                 onSearchChange={handleSearchChange}
@@ -86,7 +93,7 @@ export default function ApplicationsTable({ onDataChange }: ApplicationsTablePro
             {!loading && !error && data && data.page.totalElements > 0 && (
                 <>
                     {/* Desktop table */}
-                    <div className="hidden md:block rounded-xl md:rounded-b-none border border-[var(--border)] bg-[var(--card)] overflow-hidden shadow-sm animate-[fade-in_0.3s_ease-out]">
+                    <div className="hidden md:block rounded-2xl md:rounded-b-none border border-[var(--border)] bg-[var(--card)] overflow-hidden shadow-sm animate-[fade-in_0.3s_ease-out]">
                         <div className="overflow-x-auto">
                             <table className="min-w-full divide-y divide-[var(--border)]">
                                 <thead className="bg-[var(--muted)]/60">

--- a/frontend/components/dashboard/ApplicationsChart.tsx
+++ b/frontend/components/dashboard/ApplicationsChart.tsx
@@ -20,7 +20,7 @@ interface ApplicationsChartProps {
 }
 
 export default function ApplicationsChart({ data }: ApplicationsChartProps) {
-    const colors = useChartColors();
+    const colors = useChartColors({ dashboard: true });
 
     const chartData = useMemo(
         () => data.map((d) => ({ ...d, month: formatMonth(d.month) })),
@@ -29,18 +29,17 @@ export default function ApplicationsChart({ data }: ApplicationsChartProps) {
 
     if (data.length === 0) {
         return (
-            <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5 flex items-center justify-center h-64">
-                <p className="text-sm text-[var(--muted-foreground)]">No monthly data yet</p>
+            <div className="rounded-2xl border border-[var(--dash-card-border)] bg-[var(--dash-card)] p-6 flex items-center justify-center h-64">
+                <p className="text-sm text-[var(--dash-subtext)]">No monthly data yet</p>
             </div>
         );
     }
 
     return (
-        <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5">
-            <p className="text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)] mb-4">
-                Applications by Month
-            </p>
-            <ResponsiveContainer width="100%" height={220}>
+        <div className="rounded-2xl border border-[var(--dash-card-border)] bg-[var(--dash-card)] p-6">
+            <h3 className="text-lg font-bold text-[var(--dash-heading)]">Applications by Month</h3>
+            <p className="mt-0.5 text-xs text-[var(--dash-subtext)] mb-4">Monthly application activity</p>
+            <ResponsiveContainer width="100%" height={260}>
                 <BarChart data={chartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
                     <CartesianGrid strokeDasharray="3 3" stroke={colors.grid} vertical={false} />
                     <XAxis
@@ -65,7 +64,7 @@ export default function ApplicationsChart({ data }: ApplicationsChartProps) {
                         }}
                         cursor={{ fill: colors.cursor }}
                     />
-                    <Bar dataKey="count" fill={colors.primary} radius={[4, 4, 0, 0]} name="Applications" />
+                    <Bar dataKey="count" fill={colors.primary} radius={[6, 6, 0, 0]} name="Applications" />
                 </BarChart>
             </ResponsiveContainer>
         </div>

--- a/frontend/components/dashboard/StatsBar.tsx
+++ b/frontend/components/dashboard/StatsBar.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import { Briefcase, TrendingUp } from 'lucide-react';
 import { StatsResponse, Status } from '@/types';
-import Card from '@/components/ui/Card';
 
 interface StatusConfig {
     label: string;
@@ -31,19 +29,26 @@ export default function StatsBar({ stats }: StatsBarProps) {
     return (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
             {/* Total Applications */}
-            <div className="animate-[fade-in_0.4s_ease-out]">
-                <Card
-                    title="Total Applications"
-                    value={stats.totalApplications}
-                    icon={<Briefcase className="h-5 w-5" />}
+            <div
+                className="relative overflow-hidden rounded-2xl border border-[var(--dash-card-border)] bg-[var(--dash-card)] p-6 animate-[fade-in_0.4s_ease-out]"
+            >
+                <div
+                    className="pointer-events-none absolute -top-8 -right-8 h-24 w-24 rounded-full bg-[var(--dash-stat-circle)]"
+                    aria-hidden="true"
                 />
+                <p className="text-xs font-medium uppercase tracking-wide text-[var(--dash-subtext)]">
+                    Total Applications
+                </p>
+                <p className="mt-2 text-4xl font-bold text-[var(--dash-primary)]">
+                    {stats.totalApplications}
+                </p>
             </div>
 
             {/* Status Breakdown */}
             <div
-                className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm animate-[fade-in_0.4s_ease-out_0.1s_both]"
+                className="rounded-2xl border border-[var(--dash-card-border)] bg-[var(--dash-card)] p-6 animate-[fade-in_0.4s_ease-out_0.1s_both]"
             >
-                <p className="text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)] mb-3">
+                <p className="text-xs font-medium uppercase tracking-wide text-[var(--dash-subtext)] mb-3">
                     Status Breakdown
                 </p>
                 <div className="grid grid-cols-3 gap-2">
@@ -69,29 +74,35 @@ export default function StatsBar({ stats }: StatsBarProps) {
             </div>
 
             {/* Response Rate */}
-            <div className="animate-[fade-in_0.4s_ease-out_0.2s_both]">
-                <Card
-                    title="Response Rate"
-                    value={`${responseRatePct}%`}
-                    icon={<TrendingUp className="h-5 w-5" />}
+            <div
+                className="relative overflow-hidden rounded-2xl border border-[var(--dash-card-border)] bg-[var(--dash-card)] p-6 animate-[fade-in_0.4s_ease-out_0.2s_both]"
+            >
+                <div
+                    className="pointer-events-none absolute -top-8 -right-8 h-24 w-24 rounded-full bg-[var(--dash-stat-circle)]"
+                    aria-hidden="true"
+                />
+                <p className="text-xs font-medium uppercase tracking-wide text-[var(--dash-subtext)]">
+                    Response Rate
+                </p>
+                <p className="mt-2 text-4xl font-bold text-[var(--dash-primary)]">
+                    {responseRatePct}%
+                </p>
+                <div
+                    role="progressbar"
+                    aria-valuenow={responseRatePct}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-label="Response rate progress"
+                    className="mt-3 h-2 rounded-full bg-[var(--dash-progress-track)] overflow-hidden"
                 >
                     <div
-                        role="progressbar"
-                        aria-valuenow={responseRatePct}
-                        aria-valuemin={0}
-                        aria-valuemax={100}
-                        aria-label="Response rate progress"
-                        className="mt-3 h-2 rounded-full bg-[var(--muted)] overflow-hidden"
-                    >
-                        <div
-                            className="h-full rounded-full bg-[var(--primary)] transition-all duration-500"
-                            style={{ width: `${responseRatePct}%` }}
-                        />
-                    </div>
-                    <p className="mt-1.5 text-xs text-[var(--muted-foreground)]">
-                        of applications received a response
-                    </p>
-                </Card>
+                        className="h-full rounded-full bg-[var(--dash-primary)] transition-all duration-500"
+                        style={{ width: `${responseRatePct}%` }}
+                    />
+                </div>
+                <p className="mt-1.5 text-xs text-[var(--dash-subtext)]">
+                    of applications received a response
+                </p>
             </div>
         </div>
     );

--- a/frontend/components/dashboard/StatusChart.tsx
+++ b/frontend/components/dashboard/StatusChart.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
-import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
 import useChartColors from '@/hooks/useChartColors';
 import { Status } from '@/types';
 
@@ -21,7 +21,7 @@ interface StatusChartProps {
 }
 
 export default function StatusChart({ statusBreakdown }: StatusChartProps) {
-    const colors = useChartColors();
+    const colors = useChartColors({ dashboard: true });
 
     const chartData = useMemo(
         () => STATUS_ORDER
@@ -34,20 +34,24 @@ export default function StatusChart({ statusBreakdown }: StatusChartProps) {
         [statusBreakdown, colors.status],
     );
 
+    const total = useMemo(
+        () => chartData.reduce((sum, d) => sum + d.value, 0),
+        [chartData],
+    );
+
     if (chartData.length === 0) {
         return (
-            <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5 flex items-center justify-center h-64">
-                <p className="text-sm text-[var(--muted-foreground)]">No applications yet</p>
+            <div className="rounded-2xl border border-[var(--dash-card-border)] bg-[var(--dash-card)] p-6 flex items-center justify-center h-64">
+                <p className="text-sm text-[var(--dash-subtext)]">No applications yet</p>
             </div>
         );
     }
 
     return (
-        <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5">
-            <p className="text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)] mb-4">
-                Status Breakdown
-            </p>
-            <ResponsiveContainer width="100%" height={220}>
+        <div className="rounded-2xl border border-[var(--dash-card-border)] bg-[var(--dash-card)] p-6">
+            <h3 className="text-lg font-bold text-[var(--dash-heading)]">Status Breakdown</h3>
+            <p className="mt-0.5 text-xs text-[var(--dash-subtext)] mb-4">Current application statuses</p>
+            <ResponsiveContainer width="100%" height={200}>
                 <PieChart>
                     <Pie
                         data={chartData}
@@ -71,15 +75,41 @@ export default function StatusChart({ statusBreakdown }: StatusChartProps) {
                             fontSize: 12,
                         }}
                     />
-                    <Legend
-                        iconType="circle"
-                        iconSize={8}
-                        formatter={(value) => (
-                            <span style={{ fontSize: 12, color: colors.legendText }}>{value}</span>
-                        )}
-                    />
+                    {/* Center label */}
+                    <text
+                        x="50%"
+                        y="47%"
+                        textAnchor="middle"
+                        dominantBaseline="middle"
+                        className="fill-[var(--dash-heading)]"
+                        style={{ fontSize: 24, fontWeight: 700 }}
+                    >
+                        {total}
+                    </text>
+                    <text
+                        x="50%"
+                        y="58%"
+                        textAnchor="middle"
+                        dominantBaseline="middle"
+                        className="fill-[var(--dash-subtext)]"
+                        style={{ fontSize: 11 }}
+                    >
+                        Active
+                    </text>
                 </PieChart>
             </ResponsiveContainer>
+            {/* Custom legend */}
+            <div className="mt-3 flex flex-wrap justify-center gap-x-4 gap-y-1">
+                {chartData.map((entry) => (
+                    <div key={entry.name} className="flex items-center gap-1.5">
+                        <span
+                            className="inline-block h-2 w-2 rounded-full"
+                            style={{ backgroundColor: entry.color }}
+                        />
+                        <span className="text-xs text-[var(--dash-subtext)]">{entry.name}</span>
+                    </div>
+                ))}
+            </div>
         </div>
     );
 }

--- a/frontend/hooks/useChartColors.ts
+++ b/frontend/hooks/useChartColors.ts
@@ -30,8 +30,13 @@ interface ChartColors {
     legendText: string;
 }
 
-export default function useChartColors(): ChartColors {
+interface UseChartColorsOptions {
+    dashboard?: boolean;
+}
+
+export default function useChartColors(options?: UseChartColorsOptions): ChartColors {
     const { resolvedTheme } = useTheme();
+    const dashboard = options?.dashboard ?? false;
 
     return useMemo(() => {
         // resolvedTheme is used as a cache key — when the theme changes,
@@ -41,6 +46,20 @@ export default function useChartColors(): ChartColors {
         const status = {} as Record<Status, string>;
         for (const [key, cssVar] of Object.entries(STATUS_VAR_MAP)) {
             status[key as Status] = resolve(cssVar);
+        }
+
+        if (dashboard) {
+            return {
+                status,
+                axis: resolve('--dash-chart-axis'),
+                grid: resolve('--dash-chart-grid'),
+                tooltipBg: resolve('--dash-card'),
+                tooltipBorder: resolve('--dash-card-border'),
+                tooltipText: resolve('--dash-heading'),
+                cursor: resolve('--dash-table-row-hover'),
+                primary: resolve('--dash-primary'),
+                legendText: resolve('--dash-subtext'),
+            };
         }
 
         return {
@@ -54,5 +73,5 @@ export default function useChartColors(): ChartColors {
             primary: resolve('--primary'),
             legendText: resolve('--muted-foreground'),
         };
-    }, [resolvedTheme]);
+    }, [resolvedTheme, dashboard]);
 }


### PR DESCRIPTION
## Summary

- Apply "Obsidian Architect" dark theme to the dashboard via `.dashboard-scope` CSS variable scoping
- Add mesh gradient backgrounds, bento-style stat cards, custom donut chart legend with center label
- Extend `useChartColors` hook with `dashboard` option for chart-specific color resolution

## Changes

### Frontend (8 files modified, 0 created)
- **`globals.css`** — Added `--dash-*` CSS variables in `:root` and `.dark`, plus `.dashboard-scope` class that overrides base theme variables
- **`dashboard/page.tsx`** — Added `.dashboard-scope` wrapper, mesh gradient divs, page header, `lg:grid-cols-3` chart grid
- **`StatsBar.tsx`** — Redesigned as self-contained bento cards using `--dash-*` variables, decorative circles, large text-4xl values
- **`StatusChart.tsx`** — Custom HTML legend with colored dots, center label (`<text>` elements showing total + "Active")
- **`ApplicationsChart.tsx`** — Dashboard-aware chart colors, rounded bars, h3 heading with subtitle
- **`ApplicationsTable.tsx`** — Added optional `title` prop with subtitle
- **`useChartColors.ts`** — Added `UseChartColorsOptions` interface with `dashboard` boolean for resolving `--dash-chart-*` variables
- **`dashboard.statusChart.test.tsx`** — Updated for custom legend and center label

## Testing
- [x] `npm test -- --no-coverage` — all tests pass
- [x] `npm run lint` — no errors
- [x] `npm run build` — builds successfully
- [x] Visual smoke test via Playwright — dashboard renders correctly

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)