### PR TITLE
refactor(frontend): improve code quality, a11y, and security headers

### DIFF
--- a/frontend/__tests__/applications.newPage.test.tsx
+++ b/frontend/__tests__/applications.newPage.test.tsx
@@ -36,7 +36,7 @@ beforeEach(() => {
 
 describe('NewApplicationPage', () => {
     it('redirects to /login when not authenticated', () => {
-        mockIsAuthenticated.mockReturnValueOnce(false);
+        mockIsAuthenticated.mockReturnValue(false);
         render(<NewApplicationPage />);
         expect(mockPush).toHaveBeenCalledWith('/login');
     });

--- a/frontend/__tests__/components.errorBoundary.test.tsx
+++ b/frontend/__tests__/components.errorBoundary.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
+
+function ThrowingChild({ shouldThrow }: { shouldThrow: boolean }) {
+    if (shouldThrow) throw new Error('boom');
+    return <p>Content rendered</p>;
+}
+
+// Suppress React error boundary console noise during tests
+beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
+describe('ErrorBoundary', () => {
+    it('renders children when no error occurs', () => {
+        render(
+            <ErrorBoundary>
+                <p>Hello</p>
+            </ErrorBoundary>,
+        );
+        expect(screen.getByText('Hello')).toBeInTheDocument();
+    });
+
+    it('shows fallback UI when a child throws', () => {
+        render(
+            <ErrorBoundary>
+                <ThrowingChild shouldThrow />
+            </ErrorBoundary>,
+        );
+        expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+        expect(screen.queryByText('Content rendered')).not.toBeInTheDocument();
+    });
+
+    it('recovers when "Try again" is clicked and child no longer throws', () => {
+        const { rerender } = render(
+            <ErrorBoundary>
+                <ThrowingChild shouldThrow />
+            </ErrorBoundary>,
+        );
+        expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+
+        // Rerender with a non-throwing child so recovery succeeds
+        rerender(
+            <ErrorBoundary>
+                <ThrowingChild shouldThrow={false} />
+            </ErrorBoundary>,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+        expect(screen.getByText('Content rendered')).toBeInTheDocument();
+        expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument();
+    });
+
+    it('renders custom fallback when provided', () => {
+        render(
+            <ErrorBoundary fallback={<p>Custom fallback</p>}>
+                <ThrowingChild shouldThrow />
+            </ErrorBoundary>,
+        );
+        expect(screen.getByText('Custom fallback')).toBeInTheDocument();
+    });
+});

--- a/frontend/__tests__/settings.appearance.test.tsx
+++ b/frontend/__tests__/settings.appearance.test.tsx
@@ -48,7 +48,7 @@ beforeEach(() => {
 
 describe('SettingsPage — Appearance', () => {
     it('redirects to /login when not authenticated', () => {
-        mockIsAuthenticated.mockReturnValueOnce(false);
+        mockIsAuthenticated.mockReturnValue(false);
         render(<SettingsPage />);
         expect(mockPush).toHaveBeenCalledWith('/login');
     });

--- a/frontend/app/(app)/applications/new/page.tsx
+++ b/frontend/app/(app)/applications/new/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { isAuthenticated } from '@/lib/auth';
 import { createApplication } from '@/lib/applicationService';
+import useAuthGuard from '@/hooks/useAuthGuard';
 import { useToast } from '@/context/ToastContext';
 import { getErrorMessage } from '@/lib/errorMessages';
 import ApplicationForm, { ApplicationFormValues } from '@/components/applications/ApplicationForm';
@@ -14,15 +14,10 @@ import { Application } from '@/types';
 export default function NewApplicationPage() {
     const router = useRouter();
     const { toast } = useToast();
+    const ready = useAuthGuard();
     const [extractionKey, setExtractionKey] = useState(0);
     const [prefill, setPrefill] = useState<Application | undefined>(undefined);
     const [extracting, setExtracting] = useState(false);
-
-    useEffect(() => {
-        if (!isAuthenticated()) {
-            router.push('/login');
-        }
-    }, [router]);
 
     const handleExtracted = useCallback((data: ExtractJobPostingOutput) => {
         setPrefill({
@@ -66,6 +61,8 @@ export default function NewApplicationPage() {
     const handleCancel = useCallback(() => {
         router.push('/dashboard');
     }, [router]);
+
+    if (!ready) return null;
 
     return (
         <div className="max-w-3xl mx-auto px-4 py-8 animate-[fade-in_0.3s_ease-out]">

--- a/frontend/app/(app)/applications/page.tsx
+++ b/frontend/app/(app)/applications/page.tsx
@@ -1,31 +1,19 @@
 'use client';
 
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import { isAuthenticated } from '@/lib/auth';
-import { useMounted } from '@/hooks/useMounted';
+import useAuthGuard from '@/hooks/useAuthGuard';
 import ApplicationsTable from '@/components/applications/ApplicationsTable';
 import Spinner from '@/components/ui/Spinner';
 
 export default function ApplicationsPage() {
-    const router = useRouter();
-    const mounted = useMounted();
+    const ready = useAuthGuard();
 
-    useEffect(() => {
-        if (mounted && !isAuthenticated()) {
-            router.push('/login');
-        }
-    }, [mounted, router]);
-
-    if (!mounted) {
+    if (!ready) {
         return (
             <div className="flex items-center justify-center py-16">
                 <Spinner size="lg" />
             </div>
         );
     }
-
-    if (!isAuthenticated()) return null;
 
     return (
         <div className="max-w-7xl mx-auto px-4 py-8 space-y-6">

--- a/frontend/app/(app)/dashboard/page.tsx
+++ b/frontend/app/(app)/dashboard/page.tsx
@@ -47,10 +47,7 @@ export default function DashboardPage() {
 
   return (
     <div className="dashboard-scope relative min-h-full">
-      <div
-        className="-mx-4 -mt-8 px-4 pt-8 pb-8"
-        style={{ background: 'var(--dash-bg)' }}
-      >
+      <div className="-mx-4 -mt-8 px-4 pt-8 pb-8 bg-[var(--dash-bg)]">
         {/* Mesh gradient — top-left */}
         <div
           className="pointer-events-none absolute -left-40 -top-40 h-[600px] w-[600px] rounded-full"
@@ -74,7 +71,7 @@ export default function DashboardPage() {
           </div>
 
           {error && (
-            <div className="rounded-xl border border-[var(--dash-card-border)] bg-[var(--dash-card)] px-4 py-3 text-sm text-red-400">
+            <div className="rounded-xl border border-[var(--dash-card-border)] bg-[var(--dash-card)] px-4 py-3 text-sm text-[var(--destructive)]">
               {error}
             </div>
           )}

--- a/frontend/app/(app)/dashboard/page.tsx
+++ b/frontend/app/(app)/dashboard/page.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { getStats } from '@/lib/applicationService';
-import { isAuthenticated } from '@/lib/auth';
 import { StatsResponse } from '@/types';
+import useAuthGuard from '@/hooks/useAuthGuard';
 import Spinner from '@/components/ui/Spinner';
 import StatsBar from '@/components/dashboard/StatsBar';
 import ApplicationsChart from '@/components/dashboard/ApplicationsChart';
@@ -12,7 +11,7 @@ import StatusChart from '@/components/dashboard/StatusChart';
 import ApplicationsTable from '@/components/applications/ApplicationsTable';
 
 export default function DashboardPage() {
-  const router = useRouter();
+  const ready = useAuthGuard();
   const [stats, setStats] = useState<StatsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -29,15 +28,10 @@ export default function DashboardPage() {
   }, []);
 
   useEffect(() => {
-    if (!isAuthenticated()) {
-      router.push('/login');
-      return;
-    }
+    if (ready) fetchStats();
+  }, [ready, fetchStats]);
 
-    fetchStats();
-  }, [router, fetchStats]);
-
-  if (loading) {
+  if (!ready || loading) {
     return (
       <div className="flex items-center justify-center py-16">
         <Spinner size="lg" />

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -29,7 +29,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     }, []);
 
     return (
-        <div className="flex h-screen overflow-hidden bg-background">
+        <div className="flex h-screen overflow-hidden bg-[var(--background)]">
             {/* Desktop Sidebar */}
             <Sidebar />
 

--- a/frontend/app/(app)/settings/page.tsx
+++ b/frontend/app/(app)/settings/page.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { Sun, Moon, Monitor } from 'lucide-react';
-import { isAuthenticated, getUsername } from '@/lib/auth';
+import { getUsername } from '@/lib/auth';
 import { useTheme } from '@/context/ThemeContext';
-import { useMounted } from '@/hooks/useMounted';
+import useAuthGuard from '@/hooks/useAuthGuard';
 import { getProfile } from '@/lib/userService';
 import ProfileSection from '@/components/settings/ProfileSection';
 import ApiKeySection from '@/components/settings/ApiKeySection';
@@ -25,19 +24,16 @@ const THEME_OPTIONS: ThemeOption[] = [
 ];
 
 export default function SettingsPage() {
-    const router = useRouter();
     const { theme, setTheme } = useTheme();
-    const mounted = useMounted();
-    const username = mounted ? (getUsername() ?? '') : '';
+    const ready = useAuthGuard();
+    const username = ready ? (getUsername() ?? '') : '';
     const [hasApiKey, setHasApiKey] = useState(false);
 
     useEffect(() => {
-        if (!isAuthenticated()) {
-            router.push('/login');
-            return;
+        if (ready) {
+            getProfile().then((p) => setHasApiKey(p.hasApiKey)).catch(() => {});
         }
-        getProfile().then((p) => setHasApiKey(p.hasApiKey)).catch(() => {});
-    }, [router]);
+    }, [ready]);
 
     const handleApiKeyUpdated = useCallback((configured: boolean) => {
         setHasApiKey(configured);
@@ -68,7 +64,7 @@ export default function SettingsPage() {
                                     key={value}
                                     className={[
                                         'flex items-center gap-4 rounded-lg border px-4 py-3 cursor-pointer transition-colors',
-                                        mounted && theme === value
+                                        ready && theme === value
                                             ? 'border-[var(--primary)] bg-[var(--primary)]/5'
                                             : 'border-[var(--border)] hover:bg-[var(--muted)]',
                                     ].join(' ')}
@@ -77,7 +73,7 @@ export default function SettingsPage() {
                                         type="radio"
                                         name="theme"
                                         value={value}
-                                        checked={mounted && theme === value}
+                                        checked={ready && theme === value}
                                         onChange={() => setTheme(value)}
                                         className="accent-[var(--primary)]"
                                     />

--- a/frontend/app/Providers.tsx
+++ b/frontend/app/Providers.tsx
@@ -2,6 +2,7 @@
 
 import { ThemeProvider } from '@/context/ThemeContext';
 import { ToastProvider } from '@/context/ToastContext';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 import ApiInterceptorSetup from '@/components/layout/ApiInterceptorSetup';
 import OfflineBanner from '@/components/layout/OfflineBanner';
 
@@ -11,7 +12,9 @@ export default function Providers({ children }: { children: React.ReactNode }) {
             <ToastProvider>
                 <ApiInterceptorSetup />
                 <OfflineBanner />
-                {children}
+                <ErrorBoundary>
+                    {children}
+                </ErrorBoundary>
             </ToastProvider>
         </ThemeProvider>
     );

--- a/frontend/components/applications/ApplicationForm.tsx
+++ b/frontend/components/applications/ApplicationForm.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState } from 'react';
 import { ChevronDown } from 'lucide-react';
 import { Application, JobType, Status } from '@/types';
+import { STATUS_OPTIONS, JOB_TYPE_OPTIONS } from '@/lib/constants';
 import Button from '@/components/ui/Button';
 import DatePicker from '@/components/ui/DatePicker';
 import Input from '@/components/ui/Input';
@@ -28,22 +29,6 @@ interface Props {
     collapsibleCredentials?: boolean;
     extracting?: boolean;
 }
-
-const STATUS_OPTIONS = [
-    { value: 'APPLIED',      label: 'Applied' },
-    { value: 'SCREENING',    label: 'Screening' },
-    { value: 'INTERVIEWING', label: 'Interviewing' },
-    { value: 'OFFER',        label: 'Offer' },
-    { value: 'REJECTED',     label: 'Rejected' },
-    { value: 'WITHDRAWN',    label: 'Withdrawn' },
-];
-
-const JOB_TYPE_OPTIONS = [
-    { value: 'FULL_TIME',   label: 'Full-time' },
-    { value: 'PART_TIME',   label: 'Part-time' },
-    { value: 'CONTRACT',    label: 'Contract' },
-    { value: 'INTERNSHIP',  label: 'Internship' },
-];
 
 function todayIso(): string {
     const d = new Date();

--- a/frontend/components/applications/ApplicationForm.tsx
+++ b/frontend/components/applications/ApplicationForm.tsx
@@ -104,6 +104,7 @@ export default function ApplicationForm({ defaultValues, onSubmit, onCancel, sub
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <Input
                     label="Company Name"
+                    required
                     value={values.companyName}
                     onChange={e => set('companyName', e.target.value)}
                     error={errors.companyName}
@@ -111,6 +112,7 @@ export default function ApplicationForm({ defaultValues, onSubmit, onCancel, sub
                 />
                 <Input
                     label="Job Role"
+                    required
                     value={values.jobRole}
                     onChange={e => set('jobRole', e.target.value)}
                     error={errors.jobRole}
@@ -118,6 +120,7 @@ export default function ApplicationForm({ defaultValues, onSubmit, onCancel, sub
                 />
                 <Input
                     label="Location"
+                    required
                     value={values.location}
                     onChange={e => set('location', e.target.value)}
                     error={errors.location}
@@ -125,6 +128,7 @@ export default function ApplicationForm({ defaultValues, onSubmit, onCancel, sub
                 />
                 <DatePicker
                     label="Applied Date"
+                    required
                     value={values.appliedDate}
                     onChange={e => set('appliedDate', e.target.value)}
                     error={errors.appliedDate}

--- a/frontend/components/applications/StatusSelect.tsx
+++ b/frontend/components/applications/StatusSelect.tsx
@@ -3,18 +3,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { updateApplication } from '@/lib/applicationService';
 import { Status } from '@/types';
+import { STATUS_OPTIONS } from '@/lib/constants';
 import { StatusBadge } from '@/components/ui/Badge';
 import Spinner from '@/components/ui/Spinner';
 import { useToast } from '@/context/ToastContext';
-
-const STATUS_OPTIONS: { value: Status; label: string }[] = [
-    { value: 'APPLIED',      label: 'Applied' },
-    { value: 'SCREENING',    label: 'Screening' },
-    { value: 'INTERVIEWING', label: 'Interviewing' },
-    { value: 'OFFER',        label: 'Offer' },
-    { value: 'REJECTED',     label: 'Rejected' },
-    { value: 'WITHDRAWN',    label: 'Withdrawn' },
-];
 
 const STATUS_DOT_CLASS: Record<Status, string> = {
     APPLIED:      'bg-[var(--status-applied)]',

--- a/frontend/components/ui/Badge.tsx
+++ b/frontend/components/ui/Badge.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Status } from '@/types';
+import { STATUS_LABELS } from '@/lib/constants';
 
 // Generic variant badge
 export type BadgeVariant = 'default' | 'success' | 'warning' | 'danger' | 'info' | 'muted';
@@ -22,15 +23,6 @@ const STATUS_VARIANT: Record<Status, BadgeVariant> = {
     OFFER:        'success',
     REJECTED:     'danger',
     WITHDRAWN:    'muted',
-};
-
-const STATUS_LABEL: Record<Status, string> = {
-    APPLIED:      'Applied',
-    SCREENING:    'Screening',
-    INTERVIEWING: 'Interviewing',
-    OFFER:        'Offer',
-    REJECTED:     'Rejected',
-    WITHDRAWN:    'Withdrawn',
 };
 
 interface BadgeProps {
@@ -57,7 +49,7 @@ export default function Badge({ variant = 'default', children, className = '' }:
 export function StatusBadge({ status, className }: { status: Status; className?: string }) {
     return (
         <Badge variant={STATUS_VARIANT[status]} className={className}>
-            {STATUS_LABEL[status]}
+            {STATUS_LABELS[status]}
         </Badge>
     );
 }

--- a/frontend/components/ui/DatePicker.tsx
+++ b/frontend/components/ui/DatePicker.tsx
@@ -16,6 +16,7 @@ export default function DatePicker({
 }: DatePickerProps) {
     const generatedId = useId();
     const inputId = id ?? (label ? label.toLowerCase().replace(/\s+/g, '-') : generatedId);
+    const errorId = `${inputId}-error`;
 
     return (
         <div className="flex flex-col gap-1">
@@ -30,6 +31,8 @@ export default function DatePicker({
             <input
                 id={inputId}
                 type="date"
+                aria-invalid={error ? true : undefined}
+                aria-describedby={error ? errorId : undefined}
                 className={[
                     'w-full rounded-md border px-3 py-2 text-sm outline-none transition-colors shadow-sm',
                     'bg-[var(--background)] text-[var(--foreground)]',
@@ -43,7 +46,7 @@ export default function DatePicker({
                 {...props}
             />
             {error && (
-                <p className="text-xs text-[var(--destructive)]">{error}</p>
+                <p id={errorId} className="text-xs text-[var(--destructive)]">{error}</p>
             )}
         </div>
     );

--- a/frontend/components/ui/ErrorBoundary.tsx
+++ b/frontend/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React from 'react';
+
+interface Props {
+    children: React.ReactNode;
+    fallback?: React.ReactNode;
+}
+
+interface State {
+    hasError: boolean;
+}
+
+export default class ErrorBoundary extends React.Component<Props, State> {
+    constructor(props: Props) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(): State {
+        return { hasError: true };
+    }
+
+    private handleReset = () => {
+        this.setState({ hasError: false });
+    };
+
+    render() {
+        if (this.state.hasError) {
+            if (this.props.fallback) return this.props.fallback;
+
+            return (
+                <div className="flex min-h-[300px] items-center justify-center p-8">
+                    <div className="text-center space-y-4">
+                        <h2 className="text-lg font-semibold text-[var(--foreground)]">
+                            Something went wrong
+                        </h2>
+                        <p className="text-sm text-[var(--muted-foreground)]">
+                            An unexpected error occurred. Please try again.
+                        </p>
+                        <button
+                            onClick={this.handleReset}
+                            className="rounded-md bg-[var(--primary)] px-4 py-2 text-sm font-medium text-[var(--primary-foreground)] hover:opacity-90 transition-opacity"
+                        >
+                            Try again
+                        </button>
+                    </div>
+                </div>
+            );
+        }
+
+        return this.props.children;
+    }
+}

--- a/frontend/components/ui/Input.tsx
+++ b/frontend/components/ui/Input.tsx
@@ -24,6 +24,7 @@ export default function Input({
     const [showPassword, setShowPassword] = useState(false);
     const generatedId = useId();
     const inputId = id ?? (label ? label.toLowerCase().replace(/\s+/g, '-') : generatedId);
+    const errorId = `${inputId}-error`;
     const resolvedType = type === 'password' ? (showPassword ? 'text' : 'password') : type;
 
     return (
@@ -40,6 +41,8 @@ export default function Input({
                 <input
                     id={inputId}
                     type={resolvedType}
+                    aria-invalid={error ? true : undefined}
+                    aria-describedby={error ? errorId : undefined}
                     className={[
                         'w-full rounded-md border px-3 py-2 text-sm outline-none transition-colors shadow-sm',
                         variant === 'glass'
@@ -64,7 +67,7 @@ export default function Input({
                 )}
             </div>
             {error && (
-                <p className="text-xs text-[var(--destructive)]">{error}</p>
+                <p id={errorId} className="text-xs text-[var(--destructive)]">{error}</p>
             )}
         </div>
     );

--- a/frontend/components/ui/Select.tsx
+++ b/frontend/components/ui/Select.tsx
@@ -26,6 +26,7 @@ export default function Select({
 }: SelectProps) {
     const generatedId = useId();
     const selectId = id ?? (label ? label.toLowerCase().replace(/\s+/g, '-') : generatedId);
+    const errorId = `${selectId}-error`;
 
     return (
         <div className="flex flex-col gap-1">
@@ -40,6 +41,8 @@ export default function Select({
             <div className="relative">
                 <select
                     id={selectId}
+                    aria-invalid={error ? true : undefined}
+                    aria-describedby={error ? errorId : undefined}
                     className={[
                         'w-full rounded-md border px-3 py-2 pr-9 text-sm outline-none transition-colors appearance-none shadow-sm',
                         'bg-[var(--background)] text-[var(--foreground)]',
@@ -65,7 +68,7 @@ export default function Select({
                 <ChevronDown className="absolute right-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-[var(--muted-foreground)] pointer-events-none" />
             </div>
             {error && (
-                <p className="text-xs text-[var(--destructive)]">{error}</p>
+                <p id={errorId} className="text-xs text-[var(--destructive)]">{error}</p>
             )}
         </div>
     );

--- a/frontend/hooks/useAuthGuard.ts
+++ b/frontend/hooks/useAuthGuard.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { isAuthenticated } from '@/lib/auth';
+import { useMounted } from '@/hooks/useMounted';
+
+/**
+ * Redirects to /login if the user is not authenticated.
+ * Returns true when the page is safe to render (mounted + authenticated).
+ */
+export default function useAuthGuard(): boolean {
+    const router = useRouter();
+    const mounted = useMounted();
+
+    useEffect(() => {
+        if (mounted && !isAuthenticated()) {
+            router.push('/login');
+        }
+    }, [mounted, router]);
+
+    return mounted && isAuthenticated();
+}

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -1,8 +1,23 @@
-import { JobType } from '@/types';
+import { JobType, Status } from '@/types';
 
-export const JOB_TYPE_LABELS: Record<JobType, string> = {
-    FULL_TIME:  'Full-time',
-    PART_TIME:  'Part-time',
-    CONTRACT:   'Contract',
-    INTERNSHIP: 'Internship',
-};
+export const STATUS_OPTIONS: { value: Status; label: string }[] = [
+    { value: 'APPLIED',      label: 'Applied' },
+    { value: 'SCREENING',    label: 'Screening' },
+    { value: 'INTERVIEWING', label: 'Interviewing' },
+    { value: 'OFFER',        label: 'Offer' },
+    { value: 'REJECTED',     label: 'Rejected' },
+    { value: 'WITHDRAWN',    label: 'Withdrawn' },
+];
+
+export const STATUS_LABELS: Record<Status, string> =
+    Object.fromEntries(STATUS_OPTIONS.map(o => [o.value, o.label])) as Record<Status, string>;
+
+export const JOB_TYPE_OPTIONS: { value: JobType; label: string }[] = [
+    { value: 'FULL_TIME',   label: 'Full-time' },
+    { value: 'PART_TIME',   label: 'Part-time' },
+    { value: 'CONTRACT',    label: 'Contract' },
+    { value: 'INTERNSHIP',  label: 'Internship' },
+];
+
+export const JOB_TYPE_LABELS: Record<JobType, string> =
+    Object.fromEntries(JOB_TYPE_OPTIONS.map(o => [o.value, o.label])) as Record<JobType, string>;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,22 @@
 import type { NextConfig } from "next";
 
+const securityHeaders = [
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'X-DNS-Prefetch-Control', value: 'on' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+];
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

- **Constants centralization** — moved duplicated `STATUS_OPTIONS`, `JOB_TYPE_OPTIONS`, and `STATUS_LABELS` into `lib/constants.ts` as single source of truth, derived Record forms from arrays to prevent drift
- **Accessibility** — added `aria-describedby`, `aria-invalid` to Input/Select/DatePicker error states, `required` on mandatory form fields
- **Error Boundary** — new `ErrorBoundary` component wrapping app content in `Providers.tsx`, prevents full-app crash on unhandled render errors (4 tests)
- **Styling consistency** — fixed `bg-background` → `bg-[var(--background)]`, `text-red-400` → `text-[var(--destructive)]`, removed unnecessary inline `style={{}}`
- **Auth guard standardization** — extracted `useAuthGuard()` hook replacing 4 inconsistent per-page auth check patterns
- **Security headers** — added `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy` to `next.config.ts`

## Test plan

- [x] `npx tsc --noEmit` — type check passes
- [x] `npm test -- --no-coverage` — 375 tests pass (41 suites), including 4 new ErrorBoundary tests
- [x] `npm run lint` — no lint errors
- [ ] Manual smoke test: login, dashboard, create/edit/delete application, theme switching, settings page


🤖 Generated with [Claude Code](https://claude.com/claude-code)